### PR TITLE
Circuit Partition

### DIFF
--- a/apps/simple.cpp
+++ b/apps/simple.cpp
@@ -65,9 +65,9 @@ int main(int argc, char** argv) { // NOLINT(bugprone-exception-escape)
     const auto approxSteps  = vm["steps"].as<unsigned int>();
     const auto stepFidelity = vm["step_fidelity"].as<double>();
 
-    auto mode = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude;
-    auto sm   = HybridSchrodingerFeynmanSimulator<>::Split::Half; // sm := splitting_method
-		double bf = 0.4; // bf := balance factor
+    auto   mode = HybridSchrodingerFeynmanSimulator<>::Mode::Amplitude;
+    auto   sm   = HybridSchrodingerFeynmanSimulator<>::Split::Half; // sm := splitting_method
+    double bf   = 0.4;                                              // bf := balance factor
 
     const auto strategy = ApproximationInfo::fromString(vm["approx_when"].as<std::string>());
 
@@ -77,9 +77,9 @@ int main(int argc, char** argv) { // NOLINT(bugprone-exception-escape)
     const bool                                      verbose = vm.count("verbose") > 0;
 
     if (vm.count("simulate_file") > 0) {
-		      const std::string fname = vm["simulate_file"].as<std::string>();
-      quantumComputation      = std::make_unique<qc::QuantumComputation>(fname);
-      ddsim                   = std::make_unique<CircuitSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approximationInfo, seed);
+        const std::string fname = vm["simulate_file"].as<std::string>();
+        quantumComputation      = std::make_unique<qc::QuantumComputation>(fname);
+        ddsim                   = std::make_unique<CircuitSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approximationInfo, seed);
     } else if (vm.count("simulate_file_hybrid") > 0) {
         const std::string fname = vm["simulate_file_hybrid"].as<std::string>();
         quantumComputation      = std::make_unique<qc::QuantumComputation>(fname);
@@ -92,22 +92,21 @@ int main(int argc, char** argv) { // NOLINT(bugprone-exception-escape)
             }
         }
 
-			  if (vm.count("splitting_method") > 0) {
-          const std::string smname = vm["splitting_method"].as<std::string>();
-					if(smname == "graph_partitioning") 
-						sm  = HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>::Split::GraphPartitioning; 
-					else if(smname == "half")
-						sm  = HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>::Split::Half; 
-        } 
+        if (vm.count("splitting_method") > 0) {
+            const std::string smname = vm["splitting_method"].as<std::string>();
+            if (smname == "graph_partitioning")
+                sm = HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>::Split::GraphPartitioning;
+            else if (smname == "half")
+                sm = HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>::Split::Half;
+        }
 
-			  if (vm.count("balance_factor") > 0) {
-					bf = vm["balance_factor"].as<double>();
-					if(bf < 0.0 || bf > 1.0)
-					{
-						std::clog << "[WARNING] Balance factor should be positive and lower than 1.0. This value will be ignored.\n";
-						bf = 0.4;
-					}
-				}
+        if (vm.count("balance_factor") > 0) {
+            bf = vm["balance_factor"].as<double>();
+            if (bf < 0.0 || bf > 1.0) {
+                std::clog << "[WARNING] Balance factor should be positive and lower than 1.0. This value will be ignored.\n";
+                bf = 0.4;
+            }
+        }
 
         if (seed != 0) {
             ddsim = std::make_unique<HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>>(std::move(quantumComputation), approximationInfo, seed, mode, sm, bf, nthreads);

--- a/include/CircuitPartitioner.hpp
+++ b/include/CircuitPartitioner.hpp
@@ -1,171 +1,162 @@
 #pragma once
 
-#include <Eigen/Core>
 #include "Definitions.hpp"
 #include "QuantumComputation.hpp"
 #include "operations/Operation.hpp"
 
-#include <set>
+#include <Eigen/Core>
 #include <memory>
+#include <set>
 
-namespace graph
-{
+namespace graph {
 
-using namespace qc;
+    using namespace qc;
 
-using Qubit      = qc::Qubit;
-using QubitCount = std::size_t;
+    using Qubit      = qc::Qubit;
+    using QubitCount = std::size_t;
 
-class Vertex;
+    class Vertex;
 
-class Edge
-{
-	public:
-		Edge(Vertex* control, Vertex* target, int weight);
+    class Edge {
+    public:
+        Edge(Vertex* control, Vertex* target, int weight);
 
-		int weight() const { return weight_; }
+        int weight() const { return weight_; }
 
-		Vertex* control() const { return control_; }
-		Vertex* target()  const { return target_;  }
+        Vertex* control() const { return control_; }
+        Vertex* target() const { return target_; }
 
-	private:
-		int weight_;
+    private:
+        int weight_;
 
-		Vertex* control_;
-		Vertex* target_;
+        Vertex* control_;
+        Vertex* target_;
+    };
 
-};
+    // FS = Total weights of connected-cut-edges
+    // Weight = Total weights of connected-edges
+    class Vertex {
+    public:
+        Vertex(Qubit id); // id == qubit idx
 
-// FS = Total weights of connected-cut-edges
-// Weight = Total weights of connected-edges
-class Vertex
-{
-	public:
-		Vertex(Qubit id); // id == qubit idx
+        int   fs() const { return fs_; }
+        int   weight() const { return weight_; }
+        int   gain() const { return 2 * fs_ - weight_; }
+        Qubit id() const { return id_; }
+        bool  isFixed() const { return isFixed_; }
+        int   degree() const { return static_cast<int>(edges_.size()); }
 
-		int fs()       const { return fs_;               }
-		int weight()   const { return weight_;           }
-		int gain()     const { return 2 * fs_ - weight_; }
-		Qubit id()     const { return id_;               }
-		bool isFixed() const { return isFixed_;          }
-		int degree()   const { return static_cast<int>(edges_.size()); }
+        void                   addEdge(Edge* edge) { edges_.insert(edge); }
+        const std::set<Edge*>& edges() const { return edges_; }
 
-		void addEdge(Edge* edge) { edges_.insert(edge); }
-		const std::set<Edge*>& edges() const { return edges_; }
+        void updateWeight() {
+            weight_ = 0;
+            for (auto e: edges_)
+                weight_ += e->weight();
+        }
 
-		void updateWeight()
-		{
-			weight_ = 0;
-			for(auto e : edges_)
-				weight_ += e->weight();
-		}
+        double eVec() const { return eVec_; }
+        void   setEigenVec(double eVec) { eVec_ = eVec; }
 
-		double eVec() const { return eVec_; }
-		void setEigenVec(double eVec) { eVec_ = eVec; }
+        void setFixed() { isFixed_ = true; }
+        void setFS(int fs) { fs_ = fs; }
+        void setWeight(int w) { weight_ = w; }
 
-		void setFixed()       { isFixed_ = true; }
-		void setFS(int fs)    { fs_ = fs;        }
-		void setWeight(int w) { weight_ = w;     }
+    private:
+        int    fs_;   // for FM algorithm
+        int    weight_;
+        Qubit  id_;   // id == qubit idx
+        double eVec_; // For Spectral Partitioning
 
-	private:
-		int fs_; // for FM algorithm
-		int weight_;
-		Qubit id_; // id == qubit idx
-		double eVec_; // For Spectral Partitioning
+        bool isFixed_;
 
-		bool isFixed_;
+        std::set<Edge*> edges_;
+    };
 
-		std::set<Edge*> edges_;
-};
+    class Graph {
+    public:
+        Graph(QuantumComputation& qc);
 
+        const std::vector<Edge*>&   edges() const { return edgePtrs_; }
+        const std::vector<Vertex*>& vertices() const { return vertexPtrs_; }
 
-class Graph
-{
-	public:
-		Graph(QuantumComputation& qc);
+        Vertex* getVertex(Qubit q) { return vertexMap_[q]; }
 
-		const std::vector<Edge*>&   edges()    const { return edgePtrs_;    }
-		const std::vector<Vertex*>& vertices() const { return vertexPtrs_; }
+    private:
+        std::vector<Edge>   edges_;
+        std::vector<Vertex> vertices_;
 
-		Vertex* getVertex(Qubit q) { return vertexMap_[q]; }
+        std::vector<Edge*>   edgePtrs_;
+        std::vector<Vertex*> vertexPtrs_;
 
-	private:
-		std::vector<Edge> edges_;
-		std::vector<Vertex> vertices_;
-
-		std::vector<Edge*> edgePtrs_;
-		std::vector<Vertex*> vertexPtrs_;
-
-		std::map<Qubit, Vertex*> vertexMap_;
-};
+        std::map<Qubit, Vertex*> vertexMap_;
+    };
 
 } // namespace graph
 
 namespace qc {
 
-using namespace graph;
+    using namespace graph;
 
-class CircuitPartitioner 
-{
-	public:
-		CircuitPartitioner(QuantumComputation& qc, double balance);
-		const std::map<Qubit, Qubit>& initToPart()   const { return initToPart_; }
-		const std::map<Qubit, Qubit>& partToInit()   const { return partToInit_; }
-		const std::vector<std::pair<Qubit, Qubit>>& swapList() const { return swapList_;   }
+    class CircuitPartitioner {
+    public:
+        CircuitPartitioner(QuantumComputation& qc, double balance);
+        const std::map<Qubit, Qubit>&               initToPart() const { return initToPart_; }
+        const std::map<Qubit, Qubit>&               partToInit() const { return partToInit_; }
+        const std::vector<std::pair<Qubit, Qubit>>& swapList() const { return swapList_; }
 
-		const std::set<Qubit>& partL() const { return partL_; }
-		const std::set<Qubit>& partU() const { return partU_; }
+        const std::set<Qubit>& partL() const { return partL_; }
+        const std::set<Qubit>& partU() const { return partU_; }
 
-		Qubit getSplitQubit() const { return static_cast<Qubit>(partL_.size()); }
+        Qubit getSplitQubit() const { return static_cast<Qubit>(partL_.size()); }
 
-		bool graphPartitioning(QuantumComputation& qc);
+        bool graphPartitioning(QuantumComputation& qc);
 
-		void restoreQuantumComputation(QuantumComputation& qc);
+        void restoreQuantumComputation(QuantumComputation& qc);
 
-	private:
+    private:
+        int  halfSlicing();
+        int  initialPartitioning();
+        void spectralPartitioning();
 
-		int  halfSlicing();
-		int  initialPartitioning();
-		void spectralPartitioning();
+        // Bi-Partition
+        std::set<Vertex*> part1_;
+        std::set<Vertex*> part2_;
 
-		// Bi-Partition
-		std::set<Vertex*> part1_;
-		std::set<Vertex*> part2_; 
+        std::set<Qubit> partL_;
+        std::set<Qubit> partU_;
+        // there are used to update QuantumComputation
 
-		std::set<Qubit> partL_;
-		std::set<Qubit> partU_; 
-		// there are used to update QuantumComputation
+        // Sub-Procedures for FM
+        void                                 applyFM();
+        Vertex*                              findMaxGain();
+        bool                                 checkBalance(Vertex* v);
+        void                                 tryMove(Vertex* v, int& gainSum);
+        void                                 realMove(Vertex* v);
+        bool                                 checkCut(Edge* e);
+        void                                 updateFS(Vertex* v);
+        void                                 updateWeight(Vertex* v);
+        int                                  getTotalCut();
+        std::vector<std::pair<int, Vertex*>> orderList_;
 
-		// Sub-Procedures for FM
-		void applyFM();
-		Vertex* findMaxGain(); 
-		bool checkBalance(Vertex* v);
-		void tryMove(Vertex* v, int& gainSum);
-		void realMove(Vertex* v);
-		bool checkCut(Edge* e);
-		void updateFS(Vertex* v);
-		void updateWeight(Vertex* v);
-		int  getTotalCut();
-		std::vector<std::pair<int, Vertex*>> orderList_;
+        std::set<Vertex*> bestPartL_;
+        std::set<Vertex*> bestPartU_;
+        std::set<Vertex*> freeVertices_;
+        std::set<Vertex*> criticalVertices_;
 
-		std::set<Vertex*> bestPartL_;
-		std::set<Vertex*> bestPartU_; 
-		std::set<Vertex*> freeVertices_;
-		std::set<Vertex*> criticalVertices_;
+        // key: inital (== original) qubit
+        // value: qubit after partition
+        std::map<Qubit, Qubit> initToPart_;
 
-		// key: inital (== original) qubit
-		// value: qubit after partition
-		std::map<Qubit, Qubit> initToPart_;
+        // key: qubit after partition
+        // value: initial (== original) qubit
+        std::map<Qubit, Qubit> partToInit_;
 
-		// key: qubit after partition
-		// value: initial (== original) qubit
-		std::map<Qubit, Qubit> partToInit_;
+        std::vector<std::pair<Qubit, Qubit>> swapList_;
 
-		std::vector<std::pair<Qubit, Qubit>> swapList_;
-
-		double lb_;
-		double ub_;
-		std::unique_ptr<Graph> graph_;
-};
+        double                 lb_;
+        double                 ub_;
+        std::unique_ptr<Graph> graph_;
+    };
 
 } // namespace qc

--- a/include/CircuitPartitioner.hpp
+++ b/include/CircuitPartitioner.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <Eigen/Core>
+#include "Definitions.hpp"
+#include "QuantumComputation.hpp"
+#include "operations/Operation.hpp"
+
+#include <set>
+#include <memory>
+
+namespace graph
+{
+
+using namespace qc;
+
+using Qubit      = qc::Qubit;
+using QubitCount = std::size_t;
+
+class Vertex;
+
+class Edge
+{
+	public:
+		Edge(Vertex* control, Vertex* target, int weight);
+
+		int weight() const { return weight_; }
+
+		Vertex* control() const { return control_; }
+		Vertex* target()  const { return target_;  }
+
+	private:
+		int weight_;
+
+		Vertex* control_;
+		Vertex* target_;
+
+};
+
+// FS = Total weights of connected-cut-edges
+// Weight = Total weights of connected-edges
+class Vertex
+{
+	public:
+		Vertex(Qubit id); // id == qubit idx
+
+		int fs()       const { return fs_;               }
+		int weight()   const { return weight_;           }
+		int gain()     const { return 2 * fs_ - weight_; }
+		Qubit id()     const { return id_;               }
+		bool isFixed() const { return isFixed_;          }
+		int degree()   const { return static_cast<int>(edges_.size()); }
+
+		void addEdge(Edge* edge) { edges_.insert(edge); }
+		const std::set<Edge*>& edges() const { return edges_; }
+
+		void updateWeight()
+		{
+			weight_ = 0;
+			for(auto e : edges_)
+				weight_ += e->weight();
+		}
+
+		double eVec() const { return eVec_; }
+		void setEigenVec(double eVec) { eVec_ = eVec; }
+
+		void setFixed()       { isFixed_ = true; }
+		void setFS(int fs)    { fs_ = fs;        }
+		void setWeight(int w) { weight_ = w;     }
+
+	private:
+		int fs_; // for FM algorithm
+		int weight_;
+		Qubit id_; // id == qubit idx
+		double eVec_; // For Spectral Partitioning
+
+		bool isFixed_;
+
+		std::set<Edge*> edges_;
+};
+
+
+class Graph
+{
+	public:
+		Graph(QuantumComputation& qc);
+
+		const std::vector<Edge*>&   edges()    const { return edgePtrs_;    }
+		const std::vector<Vertex*>& vertices() const { return vertexPtrs_; }
+
+		Vertex* getVertex(Qubit q) { return vertexMap_[q]; }
+
+	private:
+		std::vector<Edge> edges_;
+		std::vector<Vertex> vertices_;
+
+		std::vector<Edge*> edgePtrs_;
+		std::vector<Vertex*> vertexPtrs_;
+
+		std::map<Qubit, Vertex*> vertexMap_;
+};
+
+} // namespace graph
+
+namespace qc {
+
+using namespace graph;
+
+class CircuitPartitioner 
+{
+	public:
+		CircuitPartitioner(QuantumComputation& qc, double balance);
+		const std::map<Qubit, Qubit>& initToPart()   const { return initToPart_; }
+		const std::map<Qubit, Qubit>& partToInit()   const { return partToInit_; }
+		const std::vector<std::pair<Qubit, Qubit>>& swapList() const { return swapList_;   }
+
+		const std::set<Qubit>& partL() const { return partL_; }
+		const std::set<Qubit>& partU() const { return partU_; }
+
+		Qubit getSplitQubit() const { return static_cast<Qubit>(partL_.size()); }
+
+		bool graphPartitioning(QuantumComputation& qc);
+
+		void restoreQuantumComputation(QuantumComputation& qc);
+
+	private:
+
+		int  halfSlicing();
+		int  initialPartitioning();
+		void spectralPartitioning();
+
+		// Bi-Partition
+		std::set<Vertex*> part1_;
+		std::set<Vertex*> part2_; 
+
+		std::set<Qubit> partL_;
+		std::set<Qubit> partU_; 
+		// there are used to update QuantumComputation
+
+		// Sub-Procedures for FM
+		void applyFM();
+		Vertex* findMaxGain(); 
+		bool checkBalance(Vertex* v);
+		void tryMove(Vertex* v, int& gainSum);
+		void realMove(Vertex* v);
+		bool checkCut(Edge* e);
+		void updateFS(Vertex* v);
+		void updateWeight(Vertex* v);
+		int  getTotalCut();
+		std::vector<std::pair<int, Vertex*>> orderList_;
+
+		std::set<Vertex*> bestPartL_;
+		std::set<Vertex*> bestPartU_; 
+		std::set<Vertex*> freeVertices_;
+		std::set<Vertex*> criticalVertices_;
+
+		// key: inital (== original) qubit
+		// value: qubit after partition
+		std::map<Qubit, Qubit> initToPart_;
+
+		// key: qubit after partition
+		// value: initial (== original) qubit
+		std::map<Qubit, Qubit> partToInit_;
+
+		std::vector<std::pair<Qubit, Qubit>> swapList_;
+
+		double lb_;
+		double ub_;
+		std::unique_ptr<Graph> graph_;
+};
+
+} // namespace qc

--- a/include/HybridSchrodingerFeynmanSimulator.hpp
+++ b/include/HybridSchrodingerFeynmanSimulator.hpp
@@ -2,8 +2,8 @@
 #define DDSIM_HYBRIDSCHRODINGERFEYNMANSIMULATOR_HPP
 
 #include "CircuitOptimizer.hpp"
-#include "CircuitSimulator.hpp"
 #include "CircuitPartitioner.hpp"
+#include "CircuitSimulator.hpp"
 #include "Operations.hpp"
 #include "QuantumComputation.hpp"
 #include "dd/Export.hpp"
@@ -36,11 +36,10 @@ public:
         // remove final measurements
         qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator<Config>::qc));
 
-        if(mode == Mode::Amplitude && split == Split::GraphPartitioning)
-				{
-          circuitPartitioner_ = std::make_unique<qc::CircuitPartitioner>(*(CircuitSimulator<Config>::qc), balance);
-					partitionSuccess = circuitPartitioner_->graphPartitioning(*(CircuitSimulator<Config>::qc));
-				}
+        if (mode == Mode::Amplitude && split == Split::GraphPartitioning) {
+            circuitPartitioner_ = std::make_unique<qc::CircuitPartitioner>(*(CircuitSimulator<Config>::qc), balance);
+            partitionSuccess    = circuitPartitioner_->graphPartitioning(*(CircuitSimulator<Config>::qc));
+        }
     }
 
     explicit HybridSchrodingerFeynmanSimulator(std::unique_ptr<qc::QuantumComputation>&& qc_,
@@ -62,16 +61,15 @@ public:
         // remove final measurements
         qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator<Config>::qc));
 
-        if(mode == Mode::Amplitude && split == Split::GraphPartitioning)
-				{
-          circuitPartitioner_ = std::make_unique<qc::CircuitPartitioner>(*(CircuitSimulator<Config>::qc), balance);
-					partitionSuccess = circuitPartitioner_->graphPartitioning(*(CircuitSimulator<Config>::qc));
-				}
+        if (mode == Mode::Amplitude && split == Split::GraphPartitioning) {
+            circuitPartitioner_ = std::make_unique<qc::CircuitPartitioner>(*(CircuitSimulator<Config>::qc), balance);
+            partitionSuccess    = circuitPartitioner_->graphPartitioning(*(CircuitSimulator<Config>::qc));
+        }
     }
 
     std::map<std::string, std::size_t> simulate(std::size_t shots) override;
 
-    Mode mode = Mode::Amplitude;
+    Mode  mode  = Mode::Amplitude;
     Split split = Split::Half;
 
     template<class ReturnType = dd::ComplexValue>
@@ -91,11 +89,10 @@ public:
         return CircuitSimulator<Config>::template getVector<ReturnType>();
     }
 
-
     //  Get # of decisions for given split_qubit, so that lower slice: q0 < i < qubit; upper slice: qubit <= i < nqubits
     std::size_t getNDecisions(qc::Qubit splitQubit);
 
-    [[nodiscard]] Mode  getMode()  const { return mode;  }
+    [[nodiscard]] Mode  getMode() const { return mode; }
     [[nodiscard]] Split getSplit() const { return split; }
 
     double getBalance() const { return balance; }
@@ -106,13 +103,13 @@ private:
 
     std::unique_ptr<qc::CircuitPartitioner> circuitPartitioner_;
 
-		// if numCut equals with half-slicing
-		// then, we don't have to do
-		// graph partitioning
-		bool   partitionSuccess;
+    // if numCut equals with half-slicing
+    // then, we don't have to do
+    // graph partitioning
+    bool   partitionSuccess;
     double balance;
-		void restoreAmplitudes();
-		void oneSwap(qc::Qubit i, qc::Qubit j);
+    void   restoreAmplitudes();
+    void   oneSwap(qc::Qubit i, qc::Qubit j);
 
     void simulateHybridTaskflow(qc::Qubit splitQubit);
     void simulateHybridAmplitudes(qc::Qubit splitQubit);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,4 +56,4 @@ add_library(MQT::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 find_package(Eigen3 REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen )
+target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(
   ${CMAKE_CURRENT_SOURCE_DIR}/HybridSchrodingerFeynmanSimulator.cpp
   ${PROJECT_SOURCE_DIR}/include/UnitarySimulator.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/UnitarySimulator.cpp
+  ${PROJECT_SOURCE_DIR}/include/CircuitPartitioner.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/CircuitPartitioner.cpp
   ${PROJECT_SOURCE_DIR}/include/PathSimulator.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/PathSimulator.cpp)
 target_include_directories(
@@ -51,3 +53,7 @@ set_target_properties(
                       $<TARGET_PROPERTY:Taskflow,INTERFACE_INCLUDE_DIRECTORIES>)
 
 add_library(MQT::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+find_package(Eigen3 REQUIRED)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen )

--- a/src/CircuitPartitioner.cpp
+++ b/src/CircuitPartitioner.cpp
@@ -1,0 +1,731 @@
+#include <memory>
+#include <cmath>
+#include <complex>
+#include <vector>
+#include <cassert>
+#include <climits>
+#include <algorithm>
+#include <stdio.h>
+#include <Eigen/Dense>
+#include <Eigen/Eigenvalues>
+#include "QuantumComputation.hpp"
+#include "CircuitPartitioner.hpp"
+
+
+namespace graph
+{
+
+using namespace qc;
+
+using QubitCount = std::size_t;
+
+typedef Eigen::MatrixXd Matrix;
+
+bool cmp(Vertex *v1, Vertex *v2)
+{
+	return v1->eVec() < v2->eVec();
+}
+
+Vertex::Vertex(Qubit qubit)
+{
+	id_       = qubit;
+	fs_      = 0;
+	eVec_ = 0;
+	weight_   = 0;
+	isFixed_ = false;
+}
+
+Edge::Edge(Vertex* control, Vertex* target, int weight)
+{
+	control_ = control;
+	target_  = target;
+	weight_  = weight;
+}
+
+Graph::Graph(QuantumComputation& qc)
+{
+	QubitCount nQubit = qc.getNqubits();
+
+	int** edge_table = new int*[nQubit];
+	for(Qubit i = 0; i < nQubit; i++)
+		edge_table[i] = new int[nQubit];
+
+	for(Qubit i = 0; i < nQubit; i++)
+	{
+		Vertex v(i);
+		vertices_.push_back(v);
+		for(Qubit j = 0; j < nQubit; j++) 
+			edge_table[i][j] = 0; // initialize edge_table
+	}
+
+	for(Qubit i = 0; i < nQubit; i++)
+	{
+		vertexMap_[i] = &(vertices_[i]);
+		vertexPtrs_.push_back( &(vertices_[i]) );
+	}
+
+	auto it = qc.begin();
+	while( it != qc.end() )
+	{
+		if((*it)->getNtargets() == 1 && (*it)->getNcontrols() == 1) 
+		{
+			int target  = static_cast<int>((*it)->getTargets()[0]);
+			int control = static_cast<int>((*it)->getControls().begin()->qubit);
+
+			assert(control != target);
+
+			edge_table[control][target] += 1;
+			edge_table[target][control] += 1;
+		}
+		++it;
+	}
+
+	for(Qubit i = 0; i < nQubit; i++)
+	{
+		for(Qubit j = i; j < nQubit; j++)
+		{
+			if(edge_table[i][j] != 0)
+			{
+				Vertex* c = vertexMap_[i];
+				Vertex* t = vertexMap_[j];
+				Edge e(c, t, edge_table[i][j]);
+				edges_.push_back(e);
+			}
+		}
+	}
+
+	for(auto& e : edges_)
+	{
+		edgePtrs_.push_back(&e);
+		e.control()->addEdge(&e);
+		e.target()->addEdge(&e);
+	}
+
+	for(auto & v : vertices_)
+		v.updateWeight();
+
+	for(Qubit i = 0; i < nQubit; i++)
+		delete [] edge_table[i];
+
+	delete [] edge_table;
+}
+
+} // namespace graph
+
+namespace qc
+{
+
+using namespace graph;
+
+CircuitPartitioner::CircuitPartitioner(QuantumComputation& qc, double balance)
+{
+	graph_ = std::make_unique<Graph>(qc);
+
+	lb_ = std::min(balance, 1 - balance);
+	ub_ = std::max(balance, 1 - balance);
+
+	//std::cout << "[Partitioner] Number of Edges: " << graph_->edges().size() << std::endl;
+	//std::cout << "[Partitioner] Number of Vertices: " << graph_->vertices().size() << std::endl;
+
+	for(auto& v : part1_)
+		partL_.insert(v->id());
+	for(auto& v : part2_)
+		partU_.insert(v->id());
+
+	if(*(partL_.begin()) != 0)
+	{
+		std::set<Qubit> temp;
+		temp   = partL_;
+		partL_ = partU_;
+		partU_ = temp;
+	}
+}
+
+bool
+CircuitPartitioner::graphPartitioning(QuantumComputation& qc)
+{
+	int halfCut = halfSlicing();
+	//std::cout << "[Partitioner] HalfCut: " << halfCut << std::endl;
+
+	int initialCut = initialPartitioning();
+	//std::cout << "[Partitioner] InitialCut: " << initialCut << std::endl;
+
+	spectralPartitioning();
+	applyFM(); // refining
+
+	int finalCut = getTotalCut();
+	int graphPartCut = finalCut;
+	//std::cout << "[Partitioner] GraphPartCut: " << graphPartCut << std::endl;
+
+	// if partitioning does not do better than
+	// simple half-slicing,
+	// we don't have to do partitioning
+	bool partitionSuccess = false;
+	if(initialCut <= graphPartCut && initialCut < halfCut)
+	{
+		partitionSuccess = true;
+		finalCut = initialPartitioning();
+	}
+	else if(graphPartCut < initialCut && graphPartCut < halfCut)
+	{
+		partitionSuccess = true;
+	}
+
+	if(partitionSuccess)
+	{
+		for(auto& v : part1_) 
+			partL_.insert(v->id());
+		for(auto& v : part2_)
+			partU_.insert(v->id());
+
+		// HSFSimulator.cpp uses size of partL as a index for 
+		// circuit slicing (sliceQubit)
+		// Therefore, we have to make partL have q0 
+		if(*(partL_.begin()) != 0)
+		{
+			std::set<Qubit> temp;
+			temp   = partL_;
+			partL_ = partU_;
+			partU_ = temp;
+		}
+
+		Qubit idx1 = 0;
+		for(auto v : partL_)
+		{
+			if(v != idx1)
+			{
+				initToPart_[v] = idx1;
+				partToInit_[idx1] = v;
+			}
+			idx1++;
+		}
+
+		Qubit idx2 = static_cast<Qubit>(partL_.size());
+		for(auto v : partU_)
+		{
+			if(v != idx2)
+			{
+				initToPart_[v] = idx2;
+				partToInit_[idx2] = v;
+			}
+			idx2++;
+		}
+
+		if(initToPart_.size() != 0)
+    {
+			auto it = qc.begin();
+			while( it != qc.end() )
+			{
+				if((*it)->getNcontrols() > 0) 
+				{
+					Qubit control = (*it)->getControls().begin()->qubit;
+					if(initToPart_.count(control))
+						(*it)->setControls({Control{initToPart_[control]}});
+				}
+	
+				auto numTarget = (*it)->getNtargets();
+				Targets targets;
+				for(auto i = 0; i < numTarget; i++)
+				{
+					Qubit target  = (*it)->getTargets()[i];
+					if(initToPart_.count(target))
+						targets.push_back(initToPart_[target]);
+				}
+	
+				if(!targets.empty())
+					(*it)->setTargets(targets);
+	
+				it++;
+			}
+		}
+
+		// partToInit is different with swapList
+		std::vector<Qubit> qubitListAfterPartition(0);
+		for(auto q : partL_)
+			qubitListAfterPartition.push_back(q);
+		for(auto q : partU_)
+			qubitListAfterPartition.push_back(q);
+
+		Qubit ptr1 = 0, ptr2 = 0;
+		int nQubit = partL_.size() + partU_.size();
+		while(ptr1 < nQubit)
+		{
+			if(qubitListAfterPartition[ptr1] != ptr1)
+			{
+				ptr2 = qubitListAfterPartition[ptr1];
+				Qubit temp = qubitListAfterPartition[ptr2];
+				swapList_.push_back(std::make_pair(ptr1, ptr2));
+				qubitListAfterPartition[ptr1] = temp;
+				qubitListAfterPartition[ptr2] = ptr2;
+				ptr1 = 0;
+			}
+			else
+				ptr1++;
+		}
+
+//		std::cout << std::endl;
+//
+//		std::cout << "InitToPart" << std::endl;
+//		for(auto kv : initToPart_)
+//			std::cout << kv.first << " <-> " << kv.second << std::endl;
+//
+//		std::cout << "PartToInit" << std::endl;
+//		for(auto kv : partToInit_)
+//			std::cout << kv.first << " <-> " << kv.second << std::endl;
+//
+//		std::cout << "Swap List " << swapList_.size() << std::endl;
+//		for(auto kv : swapList_)
+//			std::cout << kv.first << " <-> " << kv.second << std::endl;
+//
+//		std::cout << std::endl;
+//
+//		std::cout << "Partition L Size: " << partL_.size() << " |  ";
+//		for(Qubit q : partL_)
+//			std::cout << q << " ";
+//		std::cout << std::endl;
+//
+//		std::cout << "Partition U Size: " << partU_.size() << " |  ";
+//		for(Qubit q : partU_)
+//			std::cout << q << " ";
+//		std::cout << std::endl;
+	}
+
+	//std::cout << "[Partitioner] FinalCut: " << finalCut << std::endl;
+
+	return partitionSuccess;
+}
+
+void
+CircuitPartitioner::spectralPartitioning()
+{
+	QubitCount nQubit = graph_->vertices().size();
+
+	// L := Laplacian of G == D_G - A_G
+	Matrix Laplacian = Eigen::MatrixXd::Constant(nQubit, nQubit, 0.0);
+
+	// Compute D_G := Degree Matrix
+	for(auto v : graph_->vertices())
+	{
+		int qubit     = static_cast<int>(v->id());
+		double weight = static_cast<double>(v->weight());
+		Laplacian(qubit, qubit) = weight;
+	}
+
+	// Compute A_G := Adjacency Matrix
+	for(auto e : graph_->edges())
+	{
+		int control   = static_cast<int>(e->control()->id());
+		int target    = static_cast<int>(e->target()->id());
+		double weight = static_cast<double>(-1 * e->weight());
+		Laplacian(control, target) = weight;
+		Laplacian(target, control) = weight;
+	}
+
+	// Compute Eigenvalues of the Laplacian
+	// Eigen::EigenSolver<Matrix> solver(K.inverse() * Laplacian);
+	Eigen::EigenSolver<Matrix> solver(Laplacian);
+
+	auto eVal  = solver.eigenvalues();
+	auto eVec  = solver.eigenvectors();
+
+	// Find the 2nd smallest eigen value
+	double min1 = std::numeric_limits<double>::max(); // For min
+	double min2 = std::numeric_limits<double>::max(); // For 2nd min
+
+	int min1_idx = 0;
+	int min2_idx = 0;
+
+	for(size_t i = 0; i < eVal.size(); i++)
+	{
+		double val = real(eVal[i]);
+		if(min2 > val && val > min1)
+		{
+			min2     = val;
+			min2_idx = i;
+		}
+		else if(min2 > val && min1 > val)
+		{
+			min2     = min1;
+			min2_idx = min1_idx;
+			min1     = val;
+			min1_idx = i;
+		}
+	}
+
+	// Try the partition based on the sorted eigenvector
+	std::vector<Vertex*> sortedQubit; 
+	for(size_t i = 0; i < eVec.cols(); i++)
+	{
+		Vertex* v = graph_->getVertex(static_cast<Qubit>(i));
+		v->setEigenVec(real(eVec(i, min2_idx)));
+		sortedQubit.push_back(v);
+	}
+
+	std::sort(sortedQubit.begin(), sortedQubit.end(), cmp);
+
+	QubitCount nQubitLB 
+		= static_cast<QubitCount>(std::ceil(lb_ * static_cast<double>(nQubit)));
+	QubitCount nQubitUB
+		= static_cast<QubitCount>(std::floor(ub_ * static_cast<double>(nQubit)));
+
+	part1_.clear();
+	part2_.clear();
+
+	QubitCount bestPartition;
+	int minCut = INT_MAX;
+
+	for(auto i = nQubitLB; i < nQubitUB + 1; i++)
+	{
+		for(auto j = 0; j < i; j++)
+			part1_.insert(sortedQubit[j]);
+		for(auto j = i; j < nQubit; j++)
+			part2_.insert(sortedQubit[j]);
+
+		int numCut = getTotalCut();
+
+		if(numCut < minCut) 
+		{
+			minCut = numCut;
+			bestPartition = i;
+		}
+
+		part1_.clear();
+		part2_.clear();
+	}
+
+	for(QubitCount i = 0; i < bestPartition; i++)
+		part1_.insert(sortedQubit[i]);
+
+	for(QubitCount i = bestPartition; i < nQubit; i++)
+		part2_.insert(sortedQubit[i]);
+}
+
+void
+CircuitPartitioner::applyFM()
+{
+	// Step1: Initial Partitioning -> from Spectral Partitioning
+	for (auto& v : graph_->vertices())
+	{
+		freeVertices_.insert(v);
+	}
+
+	bestPartL_ = part1_;
+	bestPartU_ = part2_;
+
+	// Step2: Initialization
+	for(auto& v : graph_->vertices())
+	{
+		updateFS(v);
+		updateWeight(v);
+	}
+
+	int gainSum = 0;
+
+	// Step3: Main Loop
+	while(!freeVertices_.empty())
+	{
+		Vertex* maxVertex = nullptr;
+		maxVertex = findMaxGain();
+
+		if(maxVertex) tryMove(maxVertex, gainSum);
+		else          break;
+
+		orderList_.push_back(std::make_pair(gainSum, maxVertex));
+
+		for(auto& v : criticalVertices_)
+		{
+			updateFS(v);
+			updateWeight(v);
+		}
+	}
+
+	// Step4: Find the best move in the OrderList
+	int bestGainSum = 0;
+	int bestGainIdx = 0;
+	for(size_t i = 0; i < orderList_.size(); i++)
+	{
+		if(orderList_[i].first > bestGainSum)
+		{
+			bestGainIdx = i+1;
+			bestGainSum = orderList_[i].first;
+		}
+	}
+
+	// Step5: Execute the best move
+	for(size_t i = 0; i < bestGainIdx; i++)
+	{
+		Vertex* v = orderList_[i].second;	
+		realMove(v);
+	}
+
+	// Step6: Make the Final partitions
+	// These classes will be used 
+	// to synchronize with QuantumComputation Class
+	part1_ = bestPartL_;
+	part2_ = bestPartU_;
+}
+
+Vertex*
+CircuitPartitioner::findMaxGain()
+{
+	int MAX_GAIN = INT_MIN;
+	Vertex* maxVertex = nullptr;
+
+	for(auto& v : graph_->vertices())
+	{
+		bool breakTie = false;
+
+		if(checkBalance(v) && !v->isFixed())
+		{
+			if(v->gain() >= MAX_GAIN) breakTie = true;
+			else if(v->gain() == MAX_GAIN)
+			{
+				// Tie-Breaking Policy
+				int sizeL = static_cast<int>(part1_.size());
+				int sizeU = static_cast<int>(part2_.size());
+
+				if(part1_.count(v))
+				{
+					if(sizeL > sizeU) breakTie = true;
+				}
+				else if(part2_.count(v))
+				{
+					if(sizeU > sizeL) breakTie = true;
+				}
+			}
+
+			if(breakTie)
+			{
+				MAX_GAIN = v->gain();
+				maxVertex = v;	
+			}
+		}
+	}
+
+	return maxVertex;
+}
+
+int
+CircuitPartitioner::halfSlicing()
+{
+	QubitCount nQubit = graph_->vertices().size();
+
+	for (auto& v : graph_->vertices())
+	{
+		if(v->id() < static_cast<Qubit>(nQubit/2)) 
+			part1_.insert(v);
+		else                                       
+			part2_.insert(v);
+	}
+
+	int halfCut = getTotalCut();
+
+	return halfCut;
+}
+
+int
+CircuitPartitioner::initialPartitioning()
+{
+	QubitCount bestPartition;
+	int minCut = INT_MAX;
+
+	QubitCount nQubit = graph_->vertices().size();
+	QubitCount nQubitLB 
+		= static_cast<QubitCount>(std::ceil(lb_ * static_cast<double>(nQubit)));
+	QubitCount nQubitUB
+		= static_cast<QubitCount>(std::floor(ub_ * static_cast<double>(nQubit)));
+
+	for(auto i = nQubitLB; i < nQubitUB + 1; i++)
+	{
+		part1_.clear();
+		part2_.clear();
+
+		for(auto j = 0; j < i; j++)
+			part1_.insert(graph_->getVertex(static_cast<Qubit>(j)));
+
+		for(auto j = i; j < nQubit; j++)
+			part2_.insert(graph_->getVertex(static_cast<Qubit>(j)));
+
+		int numCut = getTotalCut();
+
+		if(numCut < minCut) 
+		{
+			minCut = numCut;
+			bestPartition = i;
+		}
+	}
+
+	part1_.clear();
+	part2_.clear();
+
+	for(auto i = 0; i < bestPartition; i++)
+		part1_.insert(graph_->getVertex(static_cast<Qubit>(i)));
+
+	for(auto i = bestPartition; i < nQubit; i++)
+		part2_.insert(graph_->getVertex(static_cast<Qubit>(i)));
+
+	int initialCut = getTotalCut();
+
+	return initialCut;
+}
+
+bool
+CircuitPartitioner::checkBalance(Vertex* v)
+{
+	int sizeL = static_cast<int>(part1_.size());
+	int sizeU = static_cast<int>(part2_.size());
+
+	int total = sizeL + sizeU;
+
+	if(part1_.count(v))
+	{
+		double lb = static_cast<double>(std::min(sizeL - 1, sizeU + 1)) 
+			        / static_cast<double>(total);   
+
+		double ub = static_cast<double>(std::max(sizeL - 1, sizeU + 1)) 
+			        / static_cast<double>(total);   
+
+		if(lb < lb_ || ub > ub_) return false;
+	}
+	else if(part2_.count(v))
+	{
+		double lb = static_cast<double>(std::min(sizeL + 1, sizeU - 1)) 
+			        / static_cast<double>(total);   
+
+		double ub = static_cast<double>(std::max(sizeL + 1, sizeU - 1)) 
+			        / static_cast<double>(total);   
+
+		if(lb < lb_ || ub > ub_) return false;
+	}
+
+	return true;
+}
+
+void
+CircuitPartitioner::tryMove(Vertex* v, int& gainSum)
+{
+	criticalVertices_.clear();
+
+	if(part1_.count(v))
+	{
+		part1_.erase(v);
+		part2_.insert(v);
+	}
+	if(part2_.count(v))
+	{
+		part2_.erase(v);
+		part1_.insert(v);
+	}
+
+	for(auto& e : v->edges())
+	{
+		criticalVertices_.insert(e->control());
+		criticalVertices_.insert(e->target());
+	}
+
+	v->setFixed();
+	freeVertices_.erase(v);
+	gainSum += v->gain();
+}
+
+void
+CircuitPartitioner::realMove(Vertex* v)
+{
+	criticalVertices_.clear();
+
+	if(bestPartL_.count(v))
+	{
+		bestPartL_.erase(v);
+		bestPartU_.insert(v);
+	}
+	if(bestPartU_.count(v))
+	{
+		bestPartU_.erase(v);
+		bestPartL_.insert(v);
+	}
+}
+
+bool
+CircuitPartitioner::checkCut(Edge* e)
+{
+	bool isCut = false;
+
+	if(part1_.count( e->control() ) )
+	{
+		if(part1_.count( e->target() ) ) isCut = false;
+		else                             isCut = true;
+	}
+	else if(part2_.count( e->control() ) )
+	{
+		if(part2_.count( e->target() ) ) isCut = false;
+		else                             isCut = true;
+	}
+
+	return isCut;
+}
+
+// FS = Total weights of connected-cut-edges
+void 
+CircuitPartitioner::updateFS(Vertex* v)
+{
+	int fs = 0;
+	for(auto& e : v->edges())
+		if(checkCut(e)) fs += e->weight();
+
+	v->setFS(fs);
+}
+
+// Weight = Total weights of connected-edges
+void 
+CircuitPartitioner::updateWeight(Vertex* v)
+{
+	int w = 0;
+	for(auto& e : v->edges())
+		w += e->weight();
+
+	v->setWeight(w);
+}
+
+int
+CircuitPartitioner::getTotalCut()
+{
+	int cut = 0;
+	for(auto e : graph_->edges())
+		if(checkCut(e)) cut += e->weight();
+
+	return cut;
+}
+
+void
+CircuitPartitioner::restoreQuantumComputation(QuantumComputation& qc)
+{
+	if(partToInit_.size() == 0) 
+		return;
+
+	auto it = qc.begin();
+	while( it != qc.end() )
+	{
+		if((*it)->getNcontrols() > 0) 
+		{
+			Qubit control = (*it)->getControls().begin()->qubit;
+			if(partToInit_.count(control))
+				(*it)->setControls({Control{partToInit_[control]}});
+		}
+
+		auto numTarget = (*it)->getNtargets();
+		Targets targets;
+		for(auto i = 0; i < numTarget; i++)
+		{
+			Qubit target  = (*it)->getTargets()[i];
+			if(partToInit_.count(target))
+				targets.push_back(partToInit_[target]);
+		}
+
+		if(!targets.empty())
+			(*it)->setTargets(targets);
+
+		it++;
+	}
+}
+
+} // namespace qc

--- a/src/CircuitPartitioner.cpp
+++ b/src/CircuitPartitioner.cpp
@@ -1,731 +1,645 @@
-#include <memory>
-#include <cmath>
-#include <complex>
-#include <vector>
-#include <cassert>
-#include <climits>
-#include <algorithm>
-#include <stdio.h>
-#include <Eigen/Dense>
-#include <Eigen/Eigenvalues>
-#include "QuantumComputation.hpp"
 #include "CircuitPartitioner.hpp"
 
+#include "QuantumComputation.hpp"
 
-namespace graph
-{
+#include <Eigen/Dense>
+#include <Eigen/Eigenvalues>
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <complex>
+#include <memory>
+#include <stdio.h>
+#include <vector>
 
-using namespace qc;
+namespace graph {
 
-using QubitCount = std::size_t;
+    using namespace qc;
 
-typedef Eigen::MatrixXd Matrix;
+    using QubitCount = std::size_t;
 
-bool cmp(Vertex *v1, Vertex *v2)
-{
-	return v1->eVec() < v2->eVec();
-}
+    typedef Eigen::MatrixXd Matrix;
 
-Vertex::Vertex(Qubit qubit)
-{
-	id_       = qubit;
-	fs_      = 0;
-	eVec_ = 0;
-	weight_   = 0;
-	isFixed_ = false;
-}
+    bool cmp(Vertex* v1, Vertex* v2) {
+        return v1->eVec() < v2->eVec();
+    }
 
-Edge::Edge(Vertex* control, Vertex* target, int weight)
-{
-	control_ = control;
-	target_  = target;
-	weight_  = weight;
-}
+    Vertex::Vertex(Qubit qubit) {
+        id_      = qubit;
+        fs_      = 0;
+        eVec_    = 0;
+        weight_  = 0;
+        isFixed_ = false;
+    }
 
-Graph::Graph(QuantumComputation& qc)
-{
-	QubitCount nQubit = qc.getNqubits();
+    Edge::Edge(Vertex* control, Vertex* target, int weight) {
+        control_ = control;
+        target_  = target;
+        weight_  = weight;
+    }
 
-	int** edge_table = new int*[nQubit];
-	for(Qubit i = 0; i < nQubit; i++)
-		edge_table[i] = new int[nQubit];
+    Graph::Graph(QuantumComputation& qc) {
+        QubitCount nQubit = qc.getNqubits();
 
-	for(Qubit i = 0; i < nQubit; i++)
-	{
-		Vertex v(i);
-		vertices_.push_back(v);
-		for(Qubit j = 0; j < nQubit; j++) 
-			edge_table[i][j] = 0; // initialize edge_table
-	}
+        int** edge_table = new int*[nQubit];
+        for (Qubit i = 0; i < nQubit; i++)
+            edge_table[i] = new int[nQubit];
 
-	for(Qubit i = 0; i < nQubit; i++)
-	{
-		vertexMap_[i] = &(vertices_[i]);
-		vertexPtrs_.push_back( &(vertices_[i]) );
-	}
+        for (Qubit i = 0; i < nQubit; i++) {
+            Vertex v(i);
+            vertices_.push_back(v);
+            for (Qubit j = 0; j < nQubit; j++)
+                edge_table[i][j] = 0; // initialize edge_table
+        }
 
-	auto it = qc.begin();
-	while( it != qc.end() )
-	{
-		if((*it)->getNtargets() == 1 && (*it)->getNcontrols() == 1) 
-		{
-			int target  = static_cast<int>((*it)->getTargets()[0]);
-			int control = static_cast<int>((*it)->getControls().begin()->qubit);
+        for (Qubit i = 0; i < nQubit; i++) {
+            vertexMap_[i] = &(vertices_[i]);
+            vertexPtrs_.push_back(&(vertices_[i]));
+        }
 
-			assert(control != target);
+        auto it = qc.begin();
+        while (it != qc.end()) {
+            if ((*it)->getNtargets() == 1 && (*it)->getNcontrols() == 1) {
+                int target  = static_cast<int>((*it)->getTargets()[0]);
+                int control = static_cast<int>((*it)->getControls().begin()->qubit);
 
-			edge_table[control][target] += 1;
-			edge_table[target][control] += 1;
-		}
-		++it;
-	}
+                assert(control != target);
 
-	for(Qubit i = 0; i < nQubit; i++)
-	{
-		for(Qubit j = i; j < nQubit; j++)
-		{
-			if(edge_table[i][j] != 0)
-			{
-				Vertex* c = vertexMap_[i];
-				Vertex* t = vertexMap_[j];
-				Edge e(c, t, edge_table[i][j]);
-				edges_.push_back(e);
-			}
-		}
-	}
+                edge_table[control][target] += 1;
+                edge_table[target][control] += 1;
+            }
+            ++it;
+        }
 
-	for(auto& e : edges_)
-	{
-		edgePtrs_.push_back(&e);
-		e.control()->addEdge(&e);
-		e.target()->addEdge(&e);
-	}
+        for (Qubit i = 0; i < nQubit; i++) {
+            for (Qubit j = i; j < nQubit; j++) {
+                if (edge_table[i][j] != 0) {
+                    Vertex* c = vertexMap_[i];
+                    Vertex* t = vertexMap_[j];
+                    Edge    e(c, t, edge_table[i][j]);
+                    edges_.push_back(e);
+                }
+            }
+        }
 
-	for(auto & v : vertices_)
-		v.updateWeight();
+        for (auto& e: edges_) {
+            edgePtrs_.push_back(&e);
+            e.control()->addEdge(&e);
+            e.target()->addEdge(&e);
+        }
 
-	for(Qubit i = 0; i < nQubit; i++)
-		delete [] edge_table[i];
+        for (auto& v: vertices_)
+            v.updateWeight();
 
-	delete [] edge_table;
-}
+        for (Qubit i = 0; i < nQubit; i++)
+            delete[] edge_table[i];
+
+        delete[] edge_table;
+    }
 
 } // namespace graph
 
-namespace qc
-{
-
-using namespace graph;
-
-CircuitPartitioner::CircuitPartitioner(QuantumComputation& qc, double balance)
-{
-	graph_ = std::make_unique<Graph>(qc);
-
-	lb_ = std::min(balance, 1 - balance);
-	ub_ = std::max(balance, 1 - balance);
-
-	//std::cout << "[Partitioner] Number of Edges: " << graph_->edges().size() << std::endl;
-	//std::cout << "[Partitioner] Number of Vertices: " << graph_->vertices().size() << std::endl;
-
-	for(auto& v : part1_)
-		partL_.insert(v->id());
-	for(auto& v : part2_)
-		partU_.insert(v->id());
-
-	if(*(partL_.begin()) != 0)
-	{
-		std::set<Qubit> temp;
-		temp   = partL_;
-		partL_ = partU_;
-		partU_ = temp;
-	}
-}
-
-bool
-CircuitPartitioner::graphPartitioning(QuantumComputation& qc)
-{
-	int halfCut = halfSlicing();
-	//std::cout << "[Partitioner] HalfCut: " << halfCut << std::endl;
-
-	int initialCut = initialPartitioning();
-	//std::cout << "[Partitioner] InitialCut: " << initialCut << std::endl;
-
-	spectralPartitioning();
-	applyFM(); // refining
-
-	int finalCut = getTotalCut();
-	int graphPartCut = finalCut;
-	//std::cout << "[Partitioner] GraphPartCut: " << graphPartCut << std::endl;
-
-	// if partitioning does not do better than
-	// simple half-slicing,
-	// we don't have to do partitioning
-	bool partitionSuccess = false;
-	if(initialCut <= graphPartCut && initialCut < halfCut)
-	{
-		partitionSuccess = true;
-		finalCut = initialPartitioning();
-	}
-	else if(graphPartCut < initialCut && graphPartCut < halfCut)
-	{
-		partitionSuccess = true;
-	}
-
-	if(partitionSuccess)
-	{
-		for(auto& v : part1_) 
-			partL_.insert(v->id());
-		for(auto& v : part2_)
-			partU_.insert(v->id());
-
-		// HSFSimulator.cpp uses size of partL as a index for 
-		// circuit slicing (sliceQubit)
-		// Therefore, we have to make partL have q0 
-		if(*(partL_.begin()) != 0)
-		{
-			std::set<Qubit> temp;
-			temp   = partL_;
-			partL_ = partU_;
-			partU_ = temp;
-		}
-
-		Qubit idx1 = 0;
-		for(auto v : partL_)
-		{
-			if(v != idx1)
-			{
-				initToPart_[v] = idx1;
-				partToInit_[idx1] = v;
-			}
-			idx1++;
-		}
-
-		Qubit idx2 = static_cast<Qubit>(partL_.size());
-		for(auto v : partU_)
-		{
-			if(v != idx2)
-			{
-				initToPart_[v] = idx2;
-				partToInit_[idx2] = v;
-			}
-			idx2++;
-		}
-
-		if(initToPart_.size() != 0)
-    {
-			auto it = qc.begin();
-			while( it != qc.end() )
-			{
-				if((*it)->getNcontrols() > 0) 
-				{
-					Qubit control = (*it)->getControls().begin()->qubit;
-					if(initToPart_.count(control))
-						(*it)->setControls({Control{initToPart_[control]}});
-				}
-	
-				auto numTarget = (*it)->getNtargets();
-				Targets targets;
-				for(auto i = 0; i < numTarget; i++)
-				{
-					Qubit target  = (*it)->getTargets()[i];
-					if(initToPart_.count(target))
-						targets.push_back(initToPart_[target]);
-				}
-	
-				if(!targets.empty())
-					(*it)->setTargets(targets);
-	
-				it++;
-			}
-		}
-
-		// partToInit is different with swapList
-		std::vector<Qubit> qubitListAfterPartition(0);
-		for(auto q : partL_)
-			qubitListAfterPartition.push_back(q);
-		for(auto q : partU_)
-			qubitListAfterPartition.push_back(q);
-
-		Qubit ptr1 = 0, ptr2 = 0;
-		int nQubit = partL_.size() + partU_.size();
-		while(ptr1 < nQubit)
-		{
-			if(qubitListAfterPartition[ptr1] != ptr1)
-			{
-				ptr2 = qubitListAfterPartition[ptr1];
-				Qubit temp = qubitListAfterPartition[ptr2];
-				swapList_.push_back(std::make_pair(ptr1, ptr2));
-				qubitListAfterPartition[ptr1] = temp;
-				qubitListAfterPartition[ptr2] = ptr2;
-				ptr1 = 0;
-			}
-			else
-				ptr1++;
-		}
-
-//		std::cout << std::endl;
-//
-//		std::cout << "InitToPart" << std::endl;
-//		for(auto kv : initToPart_)
-//			std::cout << kv.first << " <-> " << kv.second << std::endl;
-//
-//		std::cout << "PartToInit" << std::endl;
-//		for(auto kv : partToInit_)
-//			std::cout << kv.first << " <-> " << kv.second << std::endl;
-//
-//		std::cout << "Swap List " << swapList_.size() << std::endl;
-//		for(auto kv : swapList_)
-//			std::cout << kv.first << " <-> " << kv.second << std::endl;
-//
-//		std::cout << std::endl;
-//
-//		std::cout << "Partition L Size: " << partL_.size() << " |  ";
-//		for(Qubit q : partL_)
-//			std::cout << q << " ";
-//		std::cout << std::endl;
-//
-//		std::cout << "Partition U Size: " << partU_.size() << " |  ";
-//		for(Qubit q : partU_)
-//			std::cout << q << " ";
-//		std::cout << std::endl;
-	}
-
-	//std::cout << "[Partitioner] FinalCut: " << finalCut << std::endl;
-
-	return partitionSuccess;
-}
-
-void
-CircuitPartitioner::spectralPartitioning()
-{
-	QubitCount nQubit = graph_->vertices().size();
-
-	// L := Laplacian of G == D_G - A_G
-	Matrix Laplacian = Eigen::MatrixXd::Constant(nQubit, nQubit, 0.0);
-
-	// Compute D_G := Degree Matrix
-	for(auto v : graph_->vertices())
-	{
-		int qubit     = static_cast<int>(v->id());
-		double weight = static_cast<double>(v->weight());
-		Laplacian(qubit, qubit) = weight;
-	}
-
-	// Compute A_G := Adjacency Matrix
-	for(auto e : graph_->edges())
-	{
-		int control   = static_cast<int>(e->control()->id());
-		int target    = static_cast<int>(e->target()->id());
-		double weight = static_cast<double>(-1 * e->weight());
-		Laplacian(control, target) = weight;
-		Laplacian(target, control) = weight;
-	}
-
-	// Compute Eigenvalues of the Laplacian
-	// Eigen::EigenSolver<Matrix> solver(K.inverse() * Laplacian);
-	Eigen::EigenSolver<Matrix> solver(Laplacian);
-
-	auto eVal  = solver.eigenvalues();
-	auto eVec  = solver.eigenvectors();
-
-	// Find the 2nd smallest eigen value
-	double min1 = std::numeric_limits<double>::max(); // For min
-	double min2 = std::numeric_limits<double>::max(); // For 2nd min
-
-	int min1_idx = 0;
-	int min2_idx = 0;
-
-	for(size_t i = 0; i < eVal.size(); i++)
-	{
-		double val = real(eVal[i]);
-		if(min2 > val && val > min1)
-		{
-			min2     = val;
-			min2_idx = i;
-		}
-		else if(min2 > val && min1 > val)
-		{
-			min2     = min1;
-			min2_idx = min1_idx;
-			min1     = val;
-			min1_idx = i;
-		}
-	}
-
-	// Try the partition based on the sorted eigenvector
-	std::vector<Vertex*> sortedQubit; 
-	for(size_t i = 0; i < eVec.cols(); i++)
-	{
-		Vertex* v = graph_->getVertex(static_cast<Qubit>(i));
-		v->setEigenVec(real(eVec(i, min2_idx)));
-		sortedQubit.push_back(v);
-	}
-
-	std::sort(sortedQubit.begin(), sortedQubit.end(), cmp);
-
-	QubitCount nQubitLB 
-		= static_cast<QubitCount>(std::ceil(lb_ * static_cast<double>(nQubit)));
-	QubitCount nQubitUB
-		= static_cast<QubitCount>(std::floor(ub_ * static_cast<double>(nQubit)));
-
-	part1_.clear();
-	part2_.clear();
-
-	QubitCount bestPartition;
-	int minCut = INT_MAX;
-
-	for(auto i = nQubitLB; i < nQubitUB + 1; i++)
-	{
-		for(auto j = 0; j < i; j++)
-			part1_.insert(sortedQubit[j]);
-		for(auto j = i; j < nQubit; j++)
-			part2_.insert(sortedQubit[j]);
-
-		int numCut = getTotalCut();
-
-		if(numCut < minCut) 
-		{
-			minCut = numCut;
-			bestPartition = i;
-		}
-
-		part1_.clear();
-		part2_.clear();
-	}
-
-	for(QubitCount i = 0; i < bestPartition; i++)
-		part1_.insert(sortedQubit[i]);
-
-	for(QubitCount i = bestPartition; i < nQubit; i++)
-		part2_.insert(sortedQubit[i]);
-}
-
-void
-CircuitPartitioner::applyFM()
-{
-	// Step1: Initial Partitioning -> from Spectral Partitioning
-	for (auto& v : graph_->vertices())
-	{
-		freeVertices_.insert(v);
-	}
-
-	bestPartL_ = part1_;
-	bestPartU_ = part2_;
-
-	// Step2: Initialization
-	for(auto& v : graph_->vertices())
-	{
-		updateFS(v);
-		updateWeight(v);
-	}
-
-	int gainSum = 0;
-
-	// Step3: Main Loop
-	while(!freeVertices_.empty())
-	{
-		Vertex* maxVertex = nullptr;
-		maxVertex = findMaxGain();
-
-		if(maxVertex) tryMove(maxVertex, gainSum);
-		else          break;
-
-		orderList_.push_back(std::make_pair(gainSum, maxVertex));
-
-		for(auto& v : criticalVertices_)
-		{
-			updateFS(v);
-			updateWeight(v);
-		}
-	}
-
-	// Step4: Find the best move in the OrderList
-	int bestGainSum = 0;
-	int bestGainIdx = 0;
-	for(size_t i = 0; i < orderList_.size(); i++)
-	{
-		if(orderList_[i].first > bestGainSum)
-		{
-			bestGainIdx = i+1;
-			bestGainSum = orderList_[i].first;
-		}
-	}
-
-	// Step5: Execute the best move
-	for(size_t i = 0; i < bestGainIdx; i++)
-	{
-		Vertex* v = orderList_[i].second;	
-		realMove(v);
-	}
-
-	// Step6: Make the Final partitions
-	// These classes will be used 
-	// to synchronize with QuantumComputation Class
-	part1_ = bestPartL_;
-	part2_ = bestPartU_;
-}
-
-Vertex*
-CircuitPartitioner::findMaxGain()
-{
-	int MAX_GAIN = INT_MIN;
-	Vertex* maxVertex = nullptr;
-
-	for(auto& v : graph_->vertices())
-	{
-		bool breakTie = false;
-
-		if(checkBalance(v) && !v->isFixed())
-		{
-			if(v->gain() >= MAX_GAIN) breakTie = true;
-			else if(v->gain() == MAX_GAIN)
-			{
-				// Tie-Breaking Policy
-				int sizeL = static_cast<int>(part1_.size());
-				int sizeU = static_cast<int>(part2_.size());
-
-				if(part1_.count(v))
-				{
-					if(sizeL > sizeU) breakTie = true;
-				}
-				else if(part2_.count(v))
-				{
-					if(sizeU > sizeL) breakTie = true;
-				}
-			}
-
-			if(breakTie)
-			{
-				MAX_GAIN = v->gain();
-				maxVertex = v;	
-			}
-		}
-	}
-
-	return maxVertex;
-}
-
-int
-CircuitPartitioner::halfSlicing()
-{
-	QubitCount nQubit = graph_->vertices().size();
-
-	for (auto& v : graph_->vertices())
-	{
-		if(v->id() < static_cast<Qubit>(nQubit/2)) 
-			part1_.insert(v);
-		else                                       
-			part2_.insert(v);
-	}
-
-	int halfCut = getTotalCut();
-
-	return halfCut;
-}
-
-int
-CircuitPartitioner::initialPartitioning()
-{
-	QubitCount bestPartition;
-	int minCut = INT_MAX;
-
-	QubitCount nQubit = graph_->vertices().size();
-	QubitCount nQubitLB 
-		= static_cast<QubitCount>(std::ceil(lb_ * static_cast<double>(nQubit)));
-	QubitCount nQubitUB
-		= static_cast<QubitCount>(std::floor(ub_ * static_cast<double>(nQubit)));
-
-	for(auto i = nQubitLB; i < nQubitUB + 1; i++)
-	{
-		part1_.clear();
-		part2_.clear();
-
-		for(auto j = 0; j < i; j++)
-			part1_.insert(graph_->getVertex(static_cast<Qubit>(j)));
-
-		for(auto j = i; j < nQubit; j++)
-			part2_.insert(graph_->getVertex(static_cast<Qubit>(j)));
-
-		int numCut = getTotalCut();
-
-		if(numCut < minCut) 
-		{
-			minCut = numCut;
-			bestPartition = i;
-		}
-	}
-
-	part1_.clear();
-	part2_.clear();
-
-	for(auto i = 0; i < bestPartition; i++)
-		part1_.insert(graph_->getVertex(static_cast<Qubit>(i)));
-
-	for(auto i = bestPartition; i < nQubit; i++)
-		part2_.insert(graph_->getVertex(static_cast<Qubit>(i)));
-
-	int initialCut = getTotalCut();
-
-	return initialCut;
-}
-
-bool
-CircuitPartitioner::checkBalance(Vertex* v)
-{
-	int sizeL = static_cast<int>(part1_.size());
-	int sizeU = static_cast<int>(part2_.size());
-
-	int total = sizeL + sizeU;
-
-	if(part1_.count(v))
-	{
-		double lb = static_cast<double>(std::min(sizeL - 1, sizeU + 1)) 
-			        / static_cast<double>(total);   
-
-		double ub = static_cast<double>(std::max(sizeL - 1, sizeU + 1)) 
-			        / static_cast<double>(total);   
-
-		if(lb < lb_ || ub > ub_) return false;
-	}
-	else if(part2_.count(v))
-	{
-		double lb = static_cast<double>(std::min(sizeL + 1, sizeU - 1)) 
-			        / static_cast<double>(total);   
-
-		double ub = static_cast<double>(std::max(sizeL + 1, sizeU - 1)) 
-			        / static_cast<double>(total);   
-
-		if(lb < lb_ || ub > ub_) return false;
-	}
-
-	return true;
-}
-
-void
-CircuitPartitioner::tryMove(Vertex* v, int& gainSum)
-{
-	criticalVertices_.clear();
-
-	if(part1_.count(v))
-	{
-		part1_.erase(v);
-		part2_.insert(v);
-	}
-	if(part2_.count(v))
-	{
-		part2_.erase(v);
-		part1_.insert(v);
-	}
-
-	for(auto& e : v->edges())
-	{
-		criticalVertices_.insert(e->control());
-		criticalVertices_.insert(e->target());
-	}
-
-	v->setFixed();
-	freeVertices_.erase(v);
-	gainSum += v->gain();
-}
-
-void
-CircuitPartitioner::realMove(Vertex* v)
-{
-	criticalVertices_.clear();
-
-	if(bestPartL_.count(v))
-	{
-		bestPartL_.erase(v);
-		bestPartU_.insert(v);
-	}
-	if(bestPartU_.count(v))
-	{
-		bestPartU_.erase(v);
-		bestPartL_.insert(v);
-	}
-}
-
-bool
-CircuitPartitioner::checkCut(Edge* e)
-{
-	bool isCut = false;
-
-	if(part1_.count( e->control() ) )
-	{
-		if(part1_.count( e->target() ) ) isCut = false;
-		else                             isCut = true;
-	}
-	else if(part2_.count( e->control() ) )
-	{
-		if(part2_.count( e->target() ) ) isCut = false;
-		else                             isCut = true;
-	}
-
-	return isCut;
-}
-
-// FS = Total weights of connected-cut-edges
-void 
-CircuitPartitioner::updateFS(Vertex* v)
-{
-	int fs = 0;
-	for(auto& e : v->edges())
-		if(checkCut(e)) fs += e->weight();
-
-	v->setFS(fs);
-}
-
-// Weight = Total weights of connected-edges
-void 
-CircuitPartitioner::updateWeight(Vertex* v)
-{
-	int w = 0;
-	for(auto& e : v->edges())
-		w += e->weight();
-
-	v->setWeight(w);
-}
-
-int
-CircuitPartitioner::getTotalCut()
-{
-	int cut = 0;
-	for(auto e : graph_->edges())
-		if(checkCut(e)) cut += e->weight();
-
-	return cut;
-}
-
-void
-CircuitPartitioner::restoreQuantumComputation(QuantumComputation& qc)
-{
-	if(partToInit_.size() == 0) 
-		return;
-
-	auto it = qc.begin();
-	while( it != qc.end() )
-	{
-		if((*it)->getNcontrols() > 0) 
-		{
-			Qubit control = (*it)->getControls().begin()->qubit;
-			if(partToInit_.count(control))
-				(*it)->setControls({Control{partToInit_[control]}});
-		}
-
-		auto numTarget = (*it)->getNtargets();
-		Targets targets;
-		for(auto i = 0; i < numTarget; i++)
-		{
-			Qubit target  = (*it)->getTargets()[i];
-			if(partToInit_.count(target))
-				targets.push_back(partToInit_[target]);
-		}
-
-		if(!targets.empty())
-			(*it)->setTargets(targets);
-
-		it++;
-	}
-}
+namespace qc {
+
+    using namespace graph;
+
+    CircuitPartitioner::CircuitPartitioner(QuantumComputation& qc, double balance) {
+        graph_ = std::make_unique<Graph>(qc);
+
+        lb_ = std::min(balance, 1 - balance);
+        ub_ = std::max(balance, 1 - balance);
+
+        //std::cout << "[Partitioner] Number of Edges: " << graph_->edges().size() << std::endl;
+        //std::cout << "[Partitioner] Number of Vertices: " << graph_->vertices().size() << std::endl;
+
+        for (auto& v: part1_)
+            partL_.insert(v->id());
+        for (auto& v: part2_)
+            partU_.insert(v->id());
+
+        if (*(partL_.begin()) != 0) {
+            std::set<Qubit> temp;
+            temp   = partL_;
+            partL_ = partU_;
+            partU_ = temp;
+        }
+    }
+
+    bool
+    CircuitPartitioner::graphPartitioning(QuantumComputation& qc) {
+        int halfCut = halfSlicing();
+        //std::cout << "[Partitioner] HalfCut: " << halfCut << std::endl;
+
+        int initialCut = initialPartitioning();
+        //std::cout << "[Partitioner] InitialCut: " << initialCut << std::endl;
+
+        spectralPartitioning();
+        applyFM(); // refining
+
+        int finalCut     = getTotalCut();
+        int graphPartCut = finalCut;
+        //std::cout << "[Partitioner] GraphPartCut: " << graphPartCut << std::endl;
+
+        // if partitioning does not do better than
+        // simple half-slicing,
+        // we don't have to do partitioning
+        bool partitionSuccess = false;
+        if (initialCut <= graphPartCut && initialCut < halfCut) {
+            partitionSuccess = true;
+            finalCut         = initialPartitioning();
+        } else if (graphPartCut < initialCut && graphPartCut < halfCut) {
+            partitionSuccess = true;
+        }
+
+        if (partitionSuccess) {
+            for (auto& v: part1_)
+                partL_.insert(v->id());
+            for (auto& v: part2_)
+                partU_.insert(v->id());
+
+            // HSFSimulator.cpp uses size of partL as a index for
+            // circuit slicing (sliceQubit)
+            // Therefore, we have to make partL have q0
+            if (*(partL_.begin()) != 0) {
+                std::set<Qubit> temp;
+                temp   = partL_;
+                partL_ = partU_;
+                partU_ = temp;
+            }
+
+            Qubit idx1 = 0;
+            for (auto v: partL_) {
+                if (v != idx1) {
+                    initToPart_[v]    = idx1;
+                    partToInit_[idx1] = v;
+                }
+                idx1++;
+            }
+
+            Qubit idx2 = static_cast<Qubit>(partL_.size());
+            for (auto v: partU_) {
+                if (v != idx2) {
+                    initToPart_[v]    = idx2;
+                    partToInit_[idx2] = v;
+                }
+                idx2++;
+            }
+
+            if (initToPart_.size() != 0) {
+                auto it = qc.begin();
+                while (it != qc.end()) {
+                    if ((*it)->getNcontrols() > 0) {
+                        Qubit control = (*it)->getControls().begin()->qubit;
+                        if (initToPart_.count(control))
+                            (*it)->setControls({Control{initToPart_[control]}});
+                    }
+
+                    auto    numTarget = (*it)->getNtargets();
+                    Targets targets;
+                    for (auto i = 0; i < numTarget; i++) {
+                        Qubit target = (*it)->getTargets()[i];
+                        if (initToPart_.count(target))
+                            targets.push_back(initToPart_[target]);
+                    }
+
+                    if (!targets.empty())
+                        (*it)->setTargets(targets);
+
+                    it++;
+                }
+            }
+
+            // partToInit is different with swapList
+            std::vector<Qubit> qubitListAfterPartition(0);
+            for (auto q: partL_)
+                qubitListAfterPartition.push_back(q);
+            for (auto q: partU_)
+                qubitListAfterPartition.push_back(q);
+
+            Qubit ptr1 = 0, ptr2 = 0;
+            int   nQubit = partL_.size() + partU_.size();
+            while (ptr1 < nQubit) {
+                if (qubitListAfterPartition[ptr1] != ptr1) {
+                    ptr2       = qubitListAfterPartition[ptr1];
+                    Qubit temp = qubitListAfterPartition[ptr2];
+                    swapList_.push_back(std::make_pair(ptr1, ptr2));
+                    qubitListAfterPartition[ptr1] = temp;
+                    qubitListAfterPartition[ptr2] = ptr2;
+                    ptr1                          = 0;
+                } else
+                    ptr1++;
+            }
+
+            //		std::cout << std::endl;
+            //
+            //		std::cout << "InitToPart" << std::endl;
+            //		for(auto kv : initToPart_)
+            //			std::cout << kv.first << " <-> " << kv.second << std::endl;
+            //
+            //		std::cout << "PartToInit" << std::endl;
+            //		for(auto kv : partToInit_)
+            //			std::cout << kv.first << " <-> " << kv.second << std::endl;
+            //
+            //		std::cout << "Swap List " << swapList_.size() << std::endl;
+            //		for(auto kv : swapList_)
+            //			std::cout << kv.first << " <-> " << kv.second << std::endl;
+            //
+            //		std::cout << std::endl;
+            //
+            //		std::cout << "Partition L Size: " << partL_.size() << " |  ";
+            //		for(Qubit q : partL_)
+            //			std::cout << q << " ";
+            //		std::cout << std::endl;
+            //
+            //		std::cout << "Partition U Size: " << partU_.size() << " |  ";
+            //		for(Qubit q : partU_)
+            //			std::cout << q << " ";
+            //		std::cout << std::endl;
+        }
+
+        //std::cout << "[Partitioner] FinalCut: " << finalCut << std::endl;
+
+        return partitionSuccess;
+    }
+
+    void
+    CircuitPartitioner::spectralPartitioning() {
+        QubitCount nQubit = graph_->vertices().size();
+
+        // L := Laplacian of G == D_G - A_G
+        Matrix Laplacian = Eigen::MatrixXd::Constant(nQubit, nQubit, 0.0);
+
+        // Compute D_G := Degree Matrix
+        for (auto v: graph_->vertices()) {
+            int    qubit            = static_cast<int>(v->id());
+            double weight           = static_cast<double>(v->weight());
+            Laplacian(qubit, qubit) = weight;
+        }
+
+        // Compute A_G := Adjacency Matrix
+        for (auto e: graph_->edges()) {
+            int    control             = static_cast<int>(e->control()->id());
+            int    target              = static_cast<int>(e->target()->id());
+            double weight              = static_cast<double>(-1 * e->weight());
+            Laplacian(control, target) = weight;
+            Laplacian(target, control) = weight;
+        }
+
+        // Compute Eigenvalues of the Laplacian
+        // Eigen::EigenSolver<Matrix> solver(K.inverse() * Laplacian);
+        Eigen::EigenSolver<Matrix> solver(Laplacian);
+
+        auto eVal = solver.eigenvalues();
+        auto eVec = solver.eigenvectors();
+
+        // Find the 2nd smallest eigen value
+        double min1 = std::numeric_limits<double>::max(); // For min
+        double min2 = std::numeric_limits<double>::max(); // For 2nd min
+
+        int min1_idx = 0;
+        int min2_idx = 0;
+
+        for (size_t i = 0; i < eVal.size(); i++) {
+            double val = real(eVal[i]);
+            if (min2 > val && val > min1) {
+                min2     = val;
+                min2_idx = i;
+            } else if (min2 > val && min1 > val) {
+                min2     = min1;
+                min2_idx = min1_idx;
+                min1     = val;
+                min1_idx = i;
+            }
+        }
+
+        // Try the partition based on the sorted eigenvector
+        std::vector<Vertex*> sortedQubit;
+        for (size_t i = 0; i < eVec.cols(); i++) {
+            Vertex* v = graph_->getVertex(static_cast<Qubit>(i));
+            v->setEigenVec(real(eVec(i, min2_idx)));
+            sortedQubit.push_back(v);
+        }
+
+        std::sort(sortedQubit.begin(), sortedQubit.end(), cmp);
+
+        QubitCount nQubitLB = static_cast<QubitCount>(std::ceil(lb_ * static_cast<double>(nQubit)));
+        QubitCount nQubitUB = static_cast<QubitCount>(std::floor(ub_ * static_cast<double>(nQubit)));
+
+        part1_.clear();
+        part2_.clear();
+
+        QubitCount bestPartition;
+        int        minCut = INT_MAX;
+
+        for (auto i = nQubitLB; i < nQubitUB + 1; i++) {
+            for (auto j = 0; j < i; j++)
+                part1_.insert(sortedQubit[j]);
+            for (auto j = i; j < nQubit; j++)
+                part2_.insert(sortedQubit[j]);
+
+            int numCut = getTotalCut();
+
+            if (numCut < minCut) {
+                minCut        = numCut;
+                bestPartition = i;
+            }
+
+            part1_.clear();
+            part2_.clear();
+        }
+
+        for (QubitCount i = 0; i < bestPartition; i++)
+            part1_.insert(sortedQubit[i]);
+
+        for (QubitCount i = bestPartition; i < nQubit; i++)
+            part2_.insert(sortedQubit[i]);
+    }
+
+    void
+    CircuitPartitioner::applyFM() {
+        // Step1: Initial Partitioning -> from Spectral Partitioning
+        for (auto& v: graph_->vertices()) {
+            freeVertices_.insert(v);
+        }
+
+        bestPartL_ = part1_;
+        bestPartU_ = part2_;
+
+        // Step2: Initialization
+        for (auto& v: graph_->vertices()) {
+            updateFS(v);
+            updateWeight(v);
+        }
+
+        int gainSum = 0;
+
+        // Step3: Main Loop
+        while (!freeVertices_.empty()) {
+            Vertex* maxVertex = nullptr;
+            maxVertex         = findMaxGain();
+
+            if (maxVertex)
+                tryMove(maxVertex, gainSum);
+            else
+                break;
+
+            orderList_.push_back(std::make_pair(gainSum, maxVertex));
+
+            for (auto& v: criticalVertices_) {
+                updateFS(v);
+                updateWeight(v);
+            }
+        }
+
+        // Step4: Find the best move in the OrderList
+        int bestGainSum = 0;
+        int bestGainIdx = 0;
+        for (size_t i = 0; i < orderList_.size(); i++) {
+            if (orderList_[i].first > bestGainSum) {
+                bestGainIdx = i + 1;
+                bestGainSum = orderList_[i].first;
+            }
+        }
+
+        // Step5: Execute the best move
+        for (size_t i = 0; i < bestGainIdx; i++) {
+            Vertex* v = orderList_[i].second;
+            realMove(v);
+        }
+
+        // Step6: Make the Final partitions
+        // These classes will be used
+        // to synchronize with QuantumComputation Class
+        part1_ = bestPartL_;
+        part2_ = bestPartU_;
+    }
+
+    Vertex*
+    CircuitPartitioner::findMaxGain() {
+        int     MAX_GAIN  = INT_MIN;
+        Vertex* maxVertex = nullptr;
+
+        for (auto& v: graph_->vertices()) {
+            bool breakTie = false;
+
+            if (checkBalance(v) && !v->isFixed()) {
+                if (v->gain() >= MAX_GAIN)
+                    breakTie = true;
+                else if (v->gain() == MAX_GAIN) {
+                    // Tie-Breaking Policy
+                    int sizeL = static_cast<int>(part1_.size());
+                    int sizeU = static_cast<int>(part2_.size());
+
+                    if (part1_.count(v)) {
+                        if (sizeL > sizeU) breakTie = true;
+                    } else if (part2_.count(v)) {
+                        if (sizeU > sizeL) breakTie = true;
+                    }
+                }
+
+                if (breakTie) {
+                    MAX_GAIN  = v->gain();
+                    maxVertex = v;
+                }
+            }
+        }
+
+        return maxVertex;
+    }
+
+    int
+    CircuitPartitioner::halfSlicing() {
+        QubitCount nQubit = graph_->vertices().size();
+
+        for (auto& v: graph_->vertices()) {
+            if (v->id() < static_cast<Qubit>(nQubit / 2))
+                part1_.insert(v);
+            else
+                part2_.insert(v);
+        }
+
+        int halfCut = getTotalCut();
+
+        return halfCut;
+    }
+
+    int
+    CircuitPartitioner::initialPartitioning() {
+        QubitCount bestPartition;
+        int        minCut = INT_MAX;
+
+        QubitCount nQubit   = graph_->vertices().size();
+        QubitCount nQubitLB = static_cast<QubitCount>(std::ceil(lb_ * static_cast<double>(nQubit)));
+        QubitCount nQubitUB = static_cast<QubitCount>(std::floor(ub_ * static_cast<double>(nQubit)));
+
+        for (auto i = nQubitLB; i < nQubitUB + 1; i++) {
+            part1_.clear();
+            part2_.clear();
+
+            for (auto j = 0; j < i; j++)
+                part1_.insert(graph_->getVertex(static_cast<Qubit>(j)));
+
+            for (auto j = i; j < nQubit; j++)
+                part2_.insert(graph_->getVertex(static_cast<Qubit>(j)));
+
+            int numCut = getTotalCut();
+
+            if (numCut < minCut) {
+                minCut        = numCut;
+                bestPartition = i;
+            }
+        }
+
+        part1_.clear();
+        part2_.clear();
+
+        for (auto i = 0; i < bestPartition; i++)
+            part1_.insert(graph_->getVertex(static_cast<Qubit>(i)));
+
+        for (auto i = bestPartition; i < nQubit; i++)
+            part2_.insert(graph_->getVertex(static_cast<Qubit>(i)));
+
+        int initialCut = getTotalCut();
+
+        return initialCut;
+    }
+
+    bool
+    CircuitPartitioner::checkBalance(Vertex* v) {
+        int sizeL = static_cast<int>(part1_.size());
+        int sizeU = static_cast<int>(part2_.size());
+
+        int total = sizeL + sizeU;
+
+        if (part1_.count(v)) {
+            double lb = static_cast<double>(std::min(sizeL - 1, sizeU + 1)) / static_cast<double>(total);
+
+            double ub = static_cast<double>(std::max(sizeL - 1, sizeU + 1)) / static_cast<double>(total);
+
+            if (lb < lb_ || ub > ub_) return false;
+        } else if (part2_.count(v)) {
+            double lb = static_cast<double>(std::min(sizeL + 1, sizeU - 1)) / static_cast<double>(total);
+
+            double ub = static_cast<double>(std::max(sizeL + 1, sizeU - 1)) / static_cast<double>(total);
+
+            if (lb < lb_ || ub > ub_) return false;
+        }
+
+        return true;
+    }
+
+    void
+    CircuitPartitioner::tryMove(Vertex* v, int& gainSum) {
+        criticalVertices_.clear();
+
+        if (part1_.count(v)) {
+            part1_.erase(v);
+            part2_.insert(v);
+        }
+        if (part2_.count(v)) {
+            part2_.erase(v);
+            part1_.insert(v);
+        }
+
+        for (auto& e: v->edges()) {
+            criticalVertices_.insert(e->control());
+            criticalVertices_.insert(e->target());
+        }
+
+        v->setFixed();
+        freeVertices_.erase(v);
+        gainSum += v->gain();
+    }
+
+    void
+    CircuitPartitioner::realMove(Vertex* v) {
+        criticalVertices_.clear();
+
+        if (bestPartL_.count(v)) {
+            bestPartL_.erase(v);
+            bestPartU_.insert(v);
+        }
+        if (bestPartU_.count(v)) {
+            bestPartU_.erase(v);
+            bestPartL_.insert(v);
+        }
+    }
+
+    bool
+    CircuitPartitioner::checkCut(Edge* e) {
+        bool isCut = false;
+
+        if (part1_.count(e->control())) {
+            if (part1_.count(e->target()))
+                isCut = false;
+            else
+                isCut = true;
+        } else if (part2_.count(e->control())) {
+            if (part2_.count(e->target()))
+                isCut = false;
+            else
+                isCut = true;
+        }
+
+        return isCut;
+    }
+
+    // FS = Total weights of connected-cut-edges
+    void
+    CircuitPartitioner::updateFS(Vertex* v) {
+        int fs = 0;
+        for (auto& e: v->edges())
+            if (checkCut(e)) fs += e->weight();
+
+        v->setFS(fs);
+    }
+
+    // Weight = Total weights of connected-edges
+    void
+    CircuitPartitioner::updateWeight(Vertex* v) {
+        int w = 0;
+        for (auto& e: v->edges())
+            w += e->weight();
+
+        v->setWeight(w);
+    }
+
+    int
+    CircuitPartitioner::getTotalCut() {
+        int cut = 0;
+        for (auto e: graph_->edges())
+            if (checkCut(e)) cut += e->weight();
+
+        return cut;
+    }
+
+    void
+    CircuitPartitioner::restoreQuantumComputation(QuantumComputation& qc) {
+        if (partToInit_.size() == 0)
+            return;
+
+        auto it = qc.begin();
+        while (it != qc.end()) {
+            if ((*it)->getNcontrols() > 0) {
+                Qubit control = (*it)->getControls().begin()->qubit;
+                if (partToInit_.count(control))
+                    (*it)->setControls({Control{partToInit_[control]}});
+            }
+
+            auto    numTarget = (*it)->getNtargets();
+            Targets targets;
+            for (auto i = 0; i < numTarget; i++) {
+                Qubit target = (*it)->getTargets()[i];
+                if (partToInit_.count(target))
+                    targets.push_back(partToInit_[target]);
+            }
+
+            if (!targets.empty())
+                (*it)->setTargets(targets);
+
+            it++;
+        }
+    }
 
 } // namespace qc

--- a/src/HybridSchrodingerFeynmanSimulator.cpp
+++ b/src/HybridSchrodingerFeynmanSimulator.cpp
@@ -1,8 +1,22 @@
 #include "HybridSchrodingerFeynmanSimulator.hpp"
 
+#include <string>
 #include <cassert>
 #include <cmath>
+#include <iostream>
 #include <taskflow/taskflow.hpp>
+
+static void printAmpFile(std::vector<std::complex<dd::fp>>& finalAmp, std::string filename)
+{
+    std::ofstream output(filename);
+
+    output << std::setprecision(16);
+
+    for(auto& cn : finalAmp) {
+        output << cn.real() << " " << cn.imag() << "i" << std::endl;
+    }
+    output.close();
+}
 
 template<class Config>
 std::size_t HybridSchrodingerFeynmanSimulator<Config>::getNDecisions(qc::Qubit splitQubit) {
@@ -128,16 +142,31 @@ template<class Config>
 std::map<std::string, std::size_t> HybridSchrodingerFeynmanSimulator<Config>::simulate(std::size_t shots) {
     auto nqubits    = CircuitSimulator<Config>::getNumberOfQubits();
     auto splitQubit = static_cast<qc::Qubit>(nqubits / 2);
+
+    if(partitionSuccess && circuitPartitioner_ != nullptr) {
+        splitQubit = circuitPartitioner_->getSplitQubit();
+    }
+		else if(!partitionSuccess && circuitPartitioner_ != nullptr) {
+		    //std::cout << "Partition fail!" << std::endl;
+		}
+
     if (mode == Mode::DD) {
         simulateHybridTaskflow(splitQubit);
         return Simulator<Config>::measureAllNonCollapsing(shots);
     }
     simulateHybridAmplitudes(splitQubit);
+    if(partitionSuccess && circuitPartitioner_ != nullptr) {
+		    //printAmpFile(finalAmplitudes, "beforeRestore.txt");
+        restoreAmplitudes();
+        circuitPartitioner_->restoreQuantumComputation(*(CircuitSimulator<Config>::qc));
+    }
 
     if (shots > 0) {
         return Simulator<Config>::sampleFromAmplitudeVectorInPlace(finalAmplitudes, shots);
     }
     // in case no shots were requested, the final amplitudes remain untouched
+
+		//printAmpFile(finalAmplitudes, "finalAmp.txt");
     return {};
 }
 
@@ -147,6 +176,8 @@ void HybridSchrodingerFeynmanSimulator<Config>::simulateHybridTaskflow(unsigned 
     const std::size_t maxControl          = 1ULL << ndecisions;
     const std::size_t actuallyUsedThreads = std::min<std::size_t>(maxControl, nthreads);
     const std::size_t nslicesAtOnce       = std::min<std::size_t>(16, maxControl / actuallyUsedThreads);
+
+		//std::cout << "[Partitioner] Number of branches = " << ndecisions << std::endl;
 
     Simulator<Config>::rootEdge = qc::VectorDD::zero;
 
@@ -217,6 +248,9 @@ void HybridSchrodingerFeynmanSimulator<Config>::simulateHybridAmplitudes(qc::Qub
     const std::size_t nqubits             = CircuitSimulator<Config>::getNumberOfQubits();
     Simulator<Config>::rootEdge           = qc::VectorDD::zero;
 
+		//std::cout << "[Simulator] Number of Decisions = " << ndecisions << std::endl;
+		//std::cout << "[Simulator] Number of Branches = 2^" << ndecisions << " = " << maxControl << std::endl;
+
     std::vector<std::vector<std::complex<dd::fp>>> amplitudes(maxControl / nslicesOnOneCpu, std::vector<std::complex<dd::fp>>(1U << nqubits, {0, 0}));
 
     tf::Executor executor;
@@ -248,6 +282,63 @@ void HybridSchrodingerFeynmanSimulator<Config>::simulateHybridAmplitudes(qc::Qub
         oldIncrement = increment;
     }
     finalAmplitudes = std::move(amplitudes[0]);
+}
+
+template<class Config>
+void HybridSchrodingerFeynmanSimulator<Config>::oneSwap(qc::Qubit i_t, qc::Qubit j_t) {
+    qc::Qubit nQubit = static_cast<qc::Qubit>(CircuitSimulator<Config>::getNumberOfQubits());
+   
+    uint32_t i = nQubit - i_t - 1;
+    uint32_t j = nQubit - j_t - 1;
+
+    i = nQubit - i - 1;
+    j = nQubit - j - 1;
+
+    uint32_t target_mask1 = 1u << i;
+    uint32_t target_mask2 = 1u << j;
+    
+    uint32_t mask = 1u;
+    for(int k = 0; k < nQubit - 1; k++) {
+        mask = mask | (mask << 1);
+    }
+
+    uint32_t mask1 = mask >> (nQubit - j);
+    mask1 = mask1 & mask;
+    
+    uint32_t mask3 = mask << (i + 1);
+    mask3 = mask3 & mask;
+    
+    uint32_t mask2 = mask ^ mask1 ^ mask3 ^ target_mask1 ^ target_mask2; 
+    mask2 = mask2 & mask;
+    
+    uint32_t idx = 0;
+    uint32_t real_idx = 0;
+    uint32_t target_idx1 = 0;
+    uint32_t target_idx2 = 0; 
+    
+    while(idx < 1u << (nQubit - 2)) {
+        real_idx = (idx & mask1) | ((idx << 1) & mask2) | ((idx << 2) & mask3); 
+    
+        target_idx1 = real_idx | target_mask1;
+        target_idx2 = real_idx | target_mask2;
+    
+        std::complex<dd::fp> temp;
+        temp = finalAmplitudes[target_idx1];
+        finalAmplitudes[target_idx1] = finalAmplitudes[target_idx2];
+        finalAmplitudes[target_idx2] = temp;
+
+        idx = idx + 1u;
+    }
+}
+
+template<class Config>
+void HybridSchrodingerFeynmanSimulator<Config>::restoreAmplitudes() {
+    for(auto& kv : circuitPartitioner_->swapList()) {
+		    if(kv.first > kv.second)
+            oneSwap(kv.first, kv.second);
+				else
+				    oneSwap(kv.second, kv.first);
+    }
 }
 
 template class HybridSchrodingerFeynmanSimulator<dd::DDPackageConfig>;


### PR DESCRIPTION
Hi, I'm a graduate student from POSTECH, Korea.

I implemented a graph partitioning method for faster HSF simulation.
This is based on my ASP-DAC 2023 paper, "Graph Partitioning Approach for Fast Quantum Circuit Simulation."
(https://doi.org/10.1145/3566097.3567928)

1. Sicne there are many changes from the publication version, not all the features in the paper are implemented.
2. Most of the source codes are in the "CircuitPartitioner.cpp" and "CircuitPartitioner.h"
3. You can turn on the graph partitining mode by giving "--splitting_method graph_partitioning" to ddsim_simple binary.
4. I used a spectral partitioning algorithm which requires "Eigen" C++ library.
(https://ieeexplore.ieee.org/document/159993)
5. Unfortunately, this is only limited to Google supremacy circuits...
6. Experimental results are below.
https://docs.google.com/spreadsheets/d/1xG5sxuu01XgWhC-nbrjbg0QJdhRKAeq3-gL3XrBf6pA/edit#gid=0
7. I verified the results are correct by printing the amplitude vectors and comparing them with ddsim_vector binary.
(but not all the cases)

I hope this is interesting to you.
Thank you.