### PR TITLE
Add Reset Operation in Simulator

### DIFF
--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -1,6 +1,8 @@
 #include "CircuitSimulator.hpp"
 #include "algorithms/BernsteinVazirani.hpp"
 #include "algorithms/Grover.hpp"
+#include "algorithms/QFT.hpp"
+#include "algorithms/QPE.hpp"
 
 #include <gtest/gtest.h>
 #include <memory>
@@ -316,7 +318,7 @@ TEST(CircuitSimTest, TooManyQubitsForVectorTest) {
     EXPECT_THROW({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, std::range_error);
 }
 
-TEST(CircuitSimTest, BernsteinVaziraniTest) {
+TEST(CircuitSimTest, BernsteinVaziraniDynamicTest) {
     std::size_t const n        = 3;
     auto              qc       = std::make_unique<qc::BernsteinVazirani>(n, true);
     const auto        expected = qc->expected; // qc will be undefined after move
@@ -324,4 +326,20 @@ TEST(CircuitSimTest, BernsteinVaziraniTest) {
     const auto        result   = circSim->simulate(1024U);
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(result.at(expected), 1024);
+}
+
+TEST(CircuitSimTest, QPEDynamicTest) {
+    std::size_t const n       = 3;
+    auto              qc      = std::make_unique<qc::QPE>(n, true, true);
+    auto              circSim = std::make_unique<CircuitSimulator<>>(std::move(qc), 23);
+    const auto        result  = circSim->simulate(1024U);
+    EXPECT_GE(result.size(), 1);
+}
+
+TEST(CircuitSimTest, QFTDynamicTest) {
+    std::size_t const n       = 3;
+    auto              qc      = std::make_unique<qc::QFT>(n, true, true);
+    auto              circSim = std::make_unique<CircuitSimulator<>>(std::move(qc), 23);
+    const auto        result  = circSim->simulate(1024U);
+    EXPECT_GE(result.size(), 1);
 }

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -317,10 +317,11 @@ TEST(CircuitSimTest, TooManyQubitsForVectorTest) {
 }
 
 TEST(CircuitSimTest, BernsteinVaziraniTest) {
-    std::size_t const n       = 3;
-    auto              qc      = std::make_unique<qc::BernsteinVazirani>(n, true);
-    auto              circSim = std::make_unique<CircuitSimulator<>>(std::move(qc), 23);
-    const auto        result  = circSim->simulate(1024U);
+    std::size_t const n        = 3;
+    auto              qc       = std::make_unique<qc::BernsteinVazirani>(n, true);
+    const auto        expected = qc->expected; // qc will be undefined after move
+    auto              circSim  = std::make_unique<CircuitSimulator<>>(std::move(qc), 23);
+    const auto        result   = circSim->simulate(1024U);
     EXPECT_EQ(result.size(), 1);
-    EXPECT_EQ(result.at(qc->expected), 1024);
+    EXPECT_EQ(result.at(expected), 1024);
 }

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -321,4 +321,6 @@ TEST(CircuitSimTest, BernsteinVaziraniTest) {
     auto              qc      = std::make_unique<qc::BernsteinVazirani>(n, true);
     auto              circSim = std::make_unique<CircuitSimulator<>>(std::move(qc), 23);
     const auto        result  = circSim->simulate(1024U);
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result.at(qc->expected), 1024);
 }

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -1,4 +1,5 @@
 #include "CircuitSimulator.hpp"
+#include "algorithms/BernsteinVazirani.hpp"
 #include "algorithms/Grover.hpp"
 
 #include <gtest/gtest.h>
@@ -313,4 +314,11 @@ TEST(CircuitSimTest, TooManyQubitsForVectorTest) {
     CircuitSimulator ddsim(std::move(qc));
     ddsim.simulate(0);
     EXPECT_THROW({ [[maybe_unused]] auto _ = ddsim.getVector<std::complex<dd::fp>>(); }, std::range_error);
+}
+
+TEST(CircuitSimTest, BernsteinVaziraniTest) {
+    std::size_t const n       = 3;
+    auto              qc      = std::make_unique<qc::BernsteinVazirani>(n, true);
+    auto              circSim = std::make_unique<CircuitSimulator<>>(std::move(qc), 23);
+    const auto        result  = circSim->simulate(1024U);
 }


### PR DESCRIPTION
This PR adds the non-unitary reset operation to DDSIM. 

Fixes #270 