### PR TITLE
✨ Python 3.12 Support

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ matrix.config.arch == 'arm64' }}
         run: echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.14
+        uses: pypa/cibuildwheel@v2.15
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ print(counts)
 
 ## System Requirements and Building
 
-The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.14.
+The implementation is compatible with any C++17 compiler and a minimum CMake version of 3.19.
 Please refer to the [documentation](https://ddsim.readthedocs.io/en/latest/) on how to build the project.
 
 Building (and running) is continuously tested under Linux, macOS, and Windows using the [latest available system versions for GitHub Actions](https://github.com/actions/virtual-environments).

--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: C++",
     "License :: OSI Approved :: MIT License",
     "Operating System :: Microsoft :: Windows",
@@ -90,6 +91,7 @@ skip = "*-musllinux_*"
 archs = "auto64"
 test-extras = ["test"]
 test-command = "python -c \"from mqt import ddsim\""
+test-skip = "cp312-*"  # qiskit-terra does not support python 3.12 yet
 environment = { DEPLOY = "ON" }
 build-frontend = "build"
 build-verbosity = 3


### PR DESCRIPTION
Python 3.12 has hit RC1 and is thus ABI stable. Hence, one can start to distribute wheels for it.
This PR enables the respective support. Testing of the wheels is skipped for now, since not all dependencies are available for 3.12 (i.e., Qiskit).