### PR TITLE
🐛 Fix broken `manylinux` wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,7 @@ test-skip = "cp312-*"  # Qiskit Terra does not support Python 3.12 yet
 build-frontend = "build"
 
 [tool.cibuildwheel.linux]
+environment = { DEPLOY="ON" }
 
 [tool.cibuildwheel.macos]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }


### PR DESCRIPTION
## Description

Due to the way Linux wheels are built by cibuildwheel (in a manylinux docker container), environment varaiables are not passed down to the container. As a result the `CI` environment variable is not defined in the docker container, which is used to flip on the `DEPLOY` CMake setting automatically.
This has lead to manylinux wheels being built with `-march=native` that might produce errors like
```console
Illegal instruction (core dumped)
```
when trying to import the respective packages.

This PR fixes this by making sure that `DEPLOY="ON"` within cibuildwheel.

Fixes #288 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
