### PR TITLE
🩹 temporary workaround for problems with editable installs in scikit-build-core

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,6 +126,6 @@ repos:
       - id: check-sdist
         args: [--inject-junk]
         additional_dependencies:
-          - scikit-build-core[pyproject]>=0.5.0
+          - scikit-build-core[pyproject]>=0.5.0,<0.6 # TODO: remove upper cap once scikit-build-core is updated
           - setuptools-scm>=7
           - pybind11>=2.11

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,9 @@ def pylint(session: nox.Session) -> None:
 
     Simply execute `nox -rs pylint` to run PyLint.
     """
-    session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11")
+    session.install(
+        "scikit-build-core[pyproject]<0.6", "setuptools_scm", "pybind11"
+    )  # TODO: remove upper cap once scikit-build-core is updated
     session.install("--no-build-isolation", "-ve.", "pylint")
     session.run("pylint", "mqt.ddsim", *session.posargs)
 
@@ -59,7 +61,9 @@ def _run_tests(
         _extras.append("coverage")
         posargs.append("--cov-config=pyproject.toml")
 
-    session.install("scikit-build-core[pyproject]", "setuptools_scm", "pybind11", *install_args, env=env)
+    session.install(
+        "scikit-build-core[pyproject]<0.6", "setuptools_scm", "pybind11", *install_args, env=env
+    )  # TODO: remove upper cap once scikit-build-core is updated
     install_arg = f"-ve.[{','.join(_extras)}]"
     session.install("--no-build-isolation", install_arg, *install_args, env=env)
     session.run("pytest", *run_args, *posargs, env=env)
@@ -93,7 +97,11 @@ def docs(session: nox.Session) -> None:
     if args.builder != "html" and args.serve:
         session.error("Must not specify non-HTML builder with --serve")
 
-    build_requirements = ["scikit-build-core[pyproject]", "setuptools_scm", "pybind11"]
+    build_requirements = [
+        "scikit-build-core[pyproject]<0.6",
+        "setuptools_scm",
+        "pybind11",
+    ]  # TODO: remove upper cap once scikit-build-core is updated
     extra_installs = ["sphinx-autobuild"] if args.serve else []
     session.install(*build_requirements, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["scikit-build-core>=0.5.0", "setuptools-scm>=7", "pybind11>=2.11"]
+# TODO: remove upper cap once scikit-build-core is updated
+requires = ["scikit-build-core>=0.5.0,<0.6.0", "setuptools-scm>=7", "pybind11>=2.11"]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
## Description

This PR works around a couple of issues that arose with editable installs in the latest scikit-build-core version (`0.6.0`).
While this is investigated on the SBC side, we introduce an upper cap on the respective version.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
