### PR TITLE
🔥 remove check-sdist from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,14 +114,3 @@ repos:
         language: pygrep
         entry: PyBind|Numpy|Cmake|CCache|Github|PyTest|Mqt|Tum
         exclude: .pre-commit-config.yaml
-
-  # Checking sdist validity
-  - repo: https://github.com/henryiii/check-sdist
-    rev: v0.1.3
-    hooks:
-      - id: check-sdist
-        args: [--inject-junk]
-        additional_dependencies:
-          - scikit-build-core[pyproject]>=0.6.1
-          - setuptools-scm>=7
-          - pybind11>=2.11


### PR DESCRIPTION
## Description

This PR removes the slow `check-sdist` pre-commit check. It is now handled by the reusable workflows in mqt-core.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
