### PR TITLE
🚨 work around new Qiskit deprecation warnings

### DIFF
--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -58,7 +58,7 @@ Then proceed as described in the section on your operating system.
 
         backend = ddsim.DDSIMProvider().get_backend("qasm_simulator")
 
-        job = execute(circ, backend, shots=10000)
+        job = backend.run(circ, shots=10000)
         counts = job.result().get_counts(circ)
         print(counts)
 

--- a/docs/source/Quickstart.rst
+++ b/docs/source/Quickstart.rst
@@ -23,7 +23,7 @@ Further, the integration with IBM Qiskit allows users to switch to DDSIM with ju
     print([str(b) for b in provider.backends()])
     backend = provider.get_backend("qasm_simulator")
 
-    job = execute(circ, backend, shots=10000)
+    job = backend.run(circ, shots=10000)
     counts = job.result().get_counts(circ)
     print(counts)
 

--- a/docs/source/Usage.ipynb
+++ b/docs/source/Usage.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit import QuantumCircuit, execute\n",
+    "from qiskit import QuantumCircuit\n",
     "\n",
     "from mqt import ddsim\n",
     "\n",
@@ -174,7 +174,7 @@
     "# get the QasmSimulator and sample 100000 times\n",
     "backend = provider.get_backend(\"qasm_simulator\")\n",
     "print(f\"Backend version: {backend.backend_version}\")\n",
-    "job = execute(circ, backend, shots=100000)\n",
+    "job = backend.run(circ, shots=100000)\n",
     "result = job.result()\n",
     "counts = result.get_counts(circ)\n",
     "print(counts)"
@@ -200,7 +200,7 @@
     "# get the StatevectorSimulator and calculate the statevector\n",
     "backend = provider.get_backend(\"statevector_simulator\")\n",
     "print(f\"Backend version: {backend.backend_version}\")\n",
-    "job = execute(circ, backend)\n",
+    "job = backend.run(circ)\n",
     "result = job.result()\n",
     "statevector = result.get_statevector(circ)\n",
     "print(statevector)"
@@ -235,7 +235,7 @@
     "# get the HybridQasmSimulator and sample 100000 times using the amplitude mode and 4 threads\n",
     "backend = provider.get_backend(\"hybrid_qasm_simulator\")\n",
     "print(f\"Backend version: {backend.backend_version}\")\n",
-    "job = execute(circ, backend, shots=100000, mode=\"amplitude\", nthreads=4)\n",
+    "job = backend.run(circ, shots=100000, mode=\"amplitude\", nthreads=4)\n",
     "result = job.result()\n",
     "counts = result.get_counts(circ)\n",
     "print(counts)"
@@ -262,7 +262,7 @@
     "# get the HybridStatevectorSimulator and calculate the statevector using the amplitude mode and 4 threads\n",
     "backend = provider.get_backend(\"hybrid_statevector_simulator\")\n",
     "print(f\"Backend version: {backend.backend_version}\")\n",
-    "job = execute(circ, backend, mode=\"amplitude\", nthreads=4)\n",
+    "job = backend.run(circ, mode=\"amplitude\", nthreads=4)\n",
     "result = job.result()\n",
     "statevector = result.get_statevector(circ)\n",
     "print(statevector)"
@@ -285,7 +285,7 @@
    "source": [
     "backend = provider.get_backend(\"path_sim_qasm_simulator\")\n",
     "print(f\"Backend version: {backend.backend_version}\")\n",
-    "job = execute(circ, backend, shots=100000)  # uses the sequential strategy b\n",
+    "job = backend.run(circ, shots=100000)  # uses the sequential strategy b\n",
     "result = job.result()\n",
     "counts = result.get_counts(circ)\n",
     "print(counts)"
@@ -316,7 +316,7 @@
     "# get the UnitarySimulator and calculate the unitary functionality using the recursive mode\n",
     "backend = provider.get_backend(\"unitary_simulator\")\n",
     "print(f\"Backend version: {backend.backend_version}\")\n",
-    "job = execute(circ.remove_final_measurements(inplace=False), backend, mode=\"recursive\")\n",
+    "job = backend.run(circ.remove_final_measurements(inplace=False), mode=\"recursive\")\n",
     "result = job.result()\n",
     "unitary = result.get_unitary(circ)\n",
     "print(unitary)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ filterwarnings = [
     "ignore:.*Building a flow controller with keyword arguments is going to be deprecated*:PendingDeprecationWarning:qiskit",
     "ignore:.*qiskit.extensions module is pending deprecation*:PendingDeprecationWarning:qiskit",
     'ignore:.*datetime\.datetime\.utcfromtimestamp.*:DeprecationWarning:',
+    "ignore:.*qiskit.utils.parallel*:DeprecationWarning:qiskit",
+    "ignore:.*qiskit.tools.events*:DeprecationWarning:qiskit",
+    "ignore:.*qiskit.qasm*:DeprecationWarning:qiskit",
 ]
 
 [tool.coverage]

--- a/test/python/hybridsimulator/test_hybrid_qasm_simulator.py
+++ b/test/python/hybridsimulator/test_hybrid_qasm_simulator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from qiskit import BasicAer, QuantumCircuit, QuantumRegister, execute
+from qiskit import QuantumCircuit, QuantumRegister
 
 from mqt.ddsim.hybridqasmsimulator import HybridQasmSimulatorBackend
 
@@ -31,12 +31,12 @@ class MQTHybridQasmSimulatorTest(unittest.TestCase):
 
     def test_qasm_simulator_single_shot(self):
         """Test single shot run."""
-        assert execute(self.circuit, self.backend, shots=1).result().success
+        assert self.backend.run(self.circuit, shots=1).result().success
 
     def test_qasm_simulator(self):
         """Test data counts output for single circuit run against reference."""
         shots = 1024
-        result = execute(self.circuit, self.backend, shots=shots).result()
+        result = self.backend.run(self.circuit, shots=shots).result()
         threshold = 0.04 * shots
         counts = result.get_counts()
         target = {
@@ -63,7 +63,7 @@ class MQTHybridQasmSimulatorTest(unittest.TestCase):
         circuit_2.x(0)
         circuit_2.x(1)
 
-        result = execute([circuit_1, circuit_2], self.backend, shots=shots).result()
+        result = self.backend.run([circuit_1, circuit_2], shots=shots).result()
         assert result.success
 
         counts_1 = result.get_counts(circuit_1.name)
@@ -71,28 +71,6 @@ class MQTHybridQasmSimulatorTest(unittest.TestCase):
 
         assert counts_1 == {"0": shots}
         assert counts_2 == {"11": shots}
-
-    def test_basicaer_simulator(self):
-        """Test data counts output for single circuit run against reference."""
-        shots = 1024
-        result = execute(self.circuit, BasicAer.get_backend("qasm_simulator"), shots=shots).result()
-        threshold = 0.04 * shots
-        counts = result.get_counts()
-        target = {
-            "100 100": shots / 8,
-            "011 011": shots / 8,
-            "101 101": shots / 8,
-            "111 111": shots / 8,
-            "000 000": shots / 8,
-            "010 010": shots / 8,
-            "110 110": shots / 8,
-            "001 001": shots / 8,
-        }
-
-        assert len(target) == len(counts)
-        for key in target:
-            assert key in counts
-            assert abs(target[key] - counts[key]) < threshold
 
     def test_dd_mode_simulation(self):
         """Test running a single circuit."""
@@ -104,7 +82,7 @@ class MQTHybridQasmSimulatorTest(unittest.TestCase):
         circ.measure_all(inplace=True)
         print(circ.draw(fold=-1))
         self.circuit = circ
-        result = execute(self.circuit, self.backend, mode="dd").result()
+        result = self.backend.run(self.circuit, mode="dd").result()
         assert result.success
 
     def test_amplitude_mode_simulation(self):
@@ -117,5 +95,5 @@ class MQTHybridQasmSimulatorTest(unittest.TestCase):
         circ.measure_all(inplace=True)
         print(circ.draw(fold=-1))
         self.circuit = circ
-        result = execute(self.circuit, self.backend, mode="amplitude").result()
+        result = self.backend.run(self.circuit, mode="amplitude").result()
         assert result.success

--- a/test/python/hybridsimulator/test_hybrid_statevector_simulator.py
+++ b/test/python/hybridsimulator/test_hybrid_statevector_simulator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import unittest
 
-from qiskit import QuantumCircuit, QuantumRegister, execute
+from qiskit import QuantumCircuit, QuantumRegister
 
 from mqt.ddsim.hybridstatevectorsimulator import HybridStatevectorSimulatorBackend
 
@@ -24,7 +24,7 @@ class MQTHybridStatevectorSimulatorTest(unittest.TestCase):
 
     def test_statevector_output(self):
         """Test final state vector for single circuit run."""
-        result = execute(self.q_circuit, backend=self.backend, shots=0).result()
+        result = self.backend.run(self.q_circuit, shots=0).result()
         assert result.success
         actual = result.get_statevector()
 

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -88,12 +88,14 @@ def test_estimator_run_single_circuit__observable_no_params(
 def test_run_with_operator(circuits: list[QuantumCircuit], estimator: Estimator) -> None:
     """test for run with Operator as an observable"""
     circuit = circuits[0].assign_parameters([0, 1, 1, 2, 3, 5])
-    matrix = Operator([
-        [-1.06365335, 0.0, 0.0, 0.1809312],
-        [0.0, -1.83696799, 0.1809312, 0.0],
-        [0.0, 0.1809312, -0.24521829, 0.0],
-        [0.1809312, 0.0, 0.0, -1.06365335],
-    ])
+    matrix = SparsePauliOp.from_operator(
+        Operator([
+            [-1.06365335, 0.0, 0.0, 0.1809312],
+            [0.0, -1.83696799, 0.1809312, 0.0],
+            [0.0, 0.1809312, -0.24521829, 0.0],
+            [0.1809312, 0.0, 0.0, -1.06365335],
+        ])
+    )
     result = estimator.run([circuit], [matrix]).result()
 
     assert isinstance(result, EstimatorResult)

--- a/test/python/simulator/test_multi_registers_convention.py
+++ b/test/python/simulator/test_multi_registers_convention.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 
-from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister, execute
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.quantum_info import Statevector, state_fidelity
 
 from mqt.ddsim.statevectorsimulator import StatevectorSimulatorBackend
@@ -28,12 +28,12 @@ def test_circuit_multi() -> None:
 
     backend_sim = StatevectorSimulatorBackend()
 
-    result = execute(qc, backend_sim).result()
+    result = backend_sim.run(qc).result()
     counts = result.get_counts(qc)
 
     target = {"01 10": 1024}
 
-    result = execute(circ, backend_sim).result()
+    result = backend_sim.run(circ).result()
     state = result.get_statevector()
 
     assert counts == target

--- a/test/python/simulator/test_qasm_simulator.py
+++ b/test/python/simulator/test_qasm_simulator.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from qiskit import AncillaRegister, ClassicalRegister, QuantumCircuit, QuantumRegister, execute
+from qiskit import (
+    AncillaRegister,
+    ClassicalRegister,
+    QuantumCircuit,
+    QuantumRegister,
+)
 from qiskit.circuit import Parameter
 
 from mqt.ddsim.qasmsimulator import QasmSimulatorBackend
@@ -42,13 +47,13 @@ def shots() -> int:
 
 def test_qasm_simulator_single_shot(circuit: QuantumCircuit, backend: QasmSimulatorBackend):
     """Test single shot run."""
-    result = execute(circuit, backend, shots=1).result()
+    result = backend.run(circuit, shots=1).result()
     assert result.success
 
 
 def test_qasm_simulator(circuit: QuantumCircuit, backend: QasmSimulatorBackend, shots: int):
     """Test data counts output for single circuit run against reference."""
-    result = execute(circuit, backend, shots=shots).result()
+    result = backend.run(circuit, shots=shots).result()
     assert result.success
 
     threshold = 0.04 * shots
@@ -91,7 +96,8 @@ def test_qasm_simulator_support_parametrized_gates(backend: QasmSimulatorBackend
         backend.run([bare_circuit], [[np.pi]], shots=shots).result()
 
     with pytest.raises(
-        ValueError, match=r"No parameter values provided although at least one parameterized circuit was supplied."
+        ValueError,
+        match=r"No parameter values provided although at least one parameterized circuit was supplied.",
     ):
         backend.run([circuit_1, circuit_2], shots=shots).result()
 
@@ -117,7 +123,7 @@ def test_qasm_simulator_approximation(backend: QasmSimulatorBackend, shots: int)
     circuit = QuantumCircuit(2)
     circuit.h(0)
     circuit.cx(0, 1)
-    result = execute(circuit, backend, shots=shots, approximation_step_fidelity=0.4, approximation_steps=3).result()
+    result = backend.run(circuit, shots=shots, approximation_step_fidelity=0.4, approximation_steps=3).result()
     assert result.success
     counts = result.get_counts()
     assert len(counts) == 1
@@ -130,7 +136,7 @@ def test_qasm_simulator_access(backend: QasmSimulatorBackend, shots: int):
     circuit_2.x(0)
     circuit_2.x(1)
 
-    result = execute([circuit_1, circuit_2], backend, shots=shots).result()
+    result = backend.run([circuit_1, circuit_2], shots=shots).result()
     assert result.success
 
     counts_1 = result.get_counts(circuit_1.name)
@@ -172,7 +178,7 @@ def test_qasm_simulator_portfolioqaoa(backend: QasmSimulatorBackend, shots: int)
         measure q[1] -> meas[1];
         measure q[2] -> meas[2];
         """)
-    result = execute(circuit, backend, shots=shots, seed_simulator=1337).result()
+    result = backend.run(circuit, shots=shots, seed_simulator=1337).result()
     assert result.success
 
     counts = result.get_counts()
@@ -193,7 +199,7 @@ def test_qasm_simulator_mcx_no_ancilla(backend: QasmSimulatorBackend, num_contro
 
     print(backend.target.operation_names)
 
-    result = execute(circuit, backend, shots=shots).result()
+    result = backend.run(circuit, shots=shots).result()
     assert result.success
 
     counts = result.get_counts()
@@ -214,7 +220,7 @@ def test_qasm_simulator_mcx_recursion(backend: QasmSimulatorBackend, num_control
     circuit.mcx(controls, q[0], ancilla_qubits=anc, mode="recursion")
     circuit.measure(q, c)
 
-    result = execute(circuit, backend, shots=shots).result()
+    result = backend.run(circuit, shots=shots).result()
     assert result.success
 
     counts = result.get_counts()
@@ -235,7 +241,7 @@ def test_qasm_simulator_mcx_vchain(backend: QasmSimulatorBackend, num_controls: 
     circuit.mcx(controls, q[0], ancilla_qubits=anc, mode="v-chain")
     circuit.measure(q, c)
 
-    result = execute(circuit, backend, shots=shots).result()
+    result = backend.run(circuit, shots=shots).result()
     assert result.success
 
     counts = result.get_counts()
@@ -257,7 +263,7 @@ def test_qasm_simulator_mcp(backend: QasmSimulatorBackend, num_controls: int, sh
     circuit.h(q[0])
     circuit.measure(q, c)
 
-    result = execute(circuit, backend, shots=shots).result()
+    result = backend.run(circuit, shots=shots).result()
     assert result.success
 
     counts = result.get_counts()

--- a/test/python/simulator/test_statevector_simulator.py
+++ b/test/python/simulator/test_statevector_simulator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import unittest
 
-from qiskit import QuantumCircuit, QuantumRegister, execute
+from qiskit import QuantumCircuit, QuantumRegister
 
 from mqt.ddsim.statevectorsimulator import StatevectorSimulatorBackend
 
@@ -18,7 +18,7 @@ class MQTStatevectorSimulatorTest(unittest.TestCase):
 
     def test_statevector_output(self):
         """Test final state vector for single circuit run."""
-        result = execute(self.q_circuit, backend=self.backend).result()
+        result = self.backend.run(self.q_circuit).result()
         assert result.success
         actual = result.get_statevector()
 

--- a/test/python/taskbasedsimulator/test_path_sim_qasm_simulator.py
+++ b/test/python/taskbasedsimulator/test_path_sim_qasm_simulator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import unittest
 
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit
 
 from mqt.ddsim.pathqasmsimulator import PathQasmSimulatorBackend
 
@@ -31,12 +31,12 @@ class MQTQasmSimulatorTest(unittest.TestCase):
 
     def test_qasm_simulator_single_shot(self):
         """Test single shot run."""
-        assert execute(self.circuit, self.backend, shots=1).result().success
+        assert self.backend.run(self.circuit, shots=1).result().success
 
     def test_qasm_simulator(self):
         """Test data counts output for single circuit run against reference."""
         shots = 1024
-        result = execute(self.circuit, self.backend, shots=shots).result()
+        result = self.backend.run(self.circuit, shots=shots).result()
         threshold = 0.04 * shots
         counts = result.get_counts()
         target = {
@@ -63,7 +63,7 @@ class MQTQasmSimulatorTest(unittest.TestCase):
         circuit_2.x(0)
         circuit_2.x(1)
 
-        result = execute([circuit_1, circuit_2], self.backend, shots=shots).result()
+        result = self.backend.run([circuit_1, circuit_2], shots=shots).result()
         assert result.success
 
         counts_1 = result.get_counts(circuit_1.name)
@@ -75,7 +75,7 @@ class MQTQasmSimulatorTest(unittest.TestCase):
     def test_qasm_simulator_pairwise(self):
         """Test data counts output for single circuit run against reference."""
         shots = 1024
-        result = execute(self.circuit, self.backend, shots=shots, mode="pairwise_recursive").result()
+        result = self.backend.run(self.circuit, shots=shots, mode="pairwise_recursive").result()
         threshold = 0.04 * shots
         counts = result.get_counts()
         target = {
@@ -97,7 +97,7 @@ class MQTQasmSimulatorTest(unittest.TestCase):
     def test_qasm_simulator_bracket(self):
         """Test data counts output for single circuit run against reference."""
         shots = 1024
-        result = execute(self.circuit, self.backend, shots=shots, mode="bracket").result()
+        result = self.backend.run(self.circuit, shots=shots, mode="bracket").result()
 
         print(result)
         threshold = 0.04 * shots
@@ -121,7 +121,7 @@ class MQTQasmSimulatorTest(unittest.TestCase):
     def test_qasm_simulator_alternating(self):
         """Test data counts output for single circuit run against reference."""
         shots = 1024
-        result = execute(self.circuit, self.backend, shots=shots, mode="alternating").result()
+        result = self.backend.run(self.circuit, shots=shots, mode="alternating").result()
 
         print(result)
         threshold = 0.04 * shots

--- a/test/python/taskbasedsimulator/test_path_sim_statevector_simulator.py
+++ b/test/python/taskbasedsimulator/test_path_sim_statevector_simulator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 import unittest
 
-from qiskit import QuantumCircuit, QuantumRegister, execute
+from qiskit import QuantumCircuit, QuantumRegister
 
 from mqt.ddsim.pathstatevectorsimulator import PathStatevectorSimulatorBackend
 
@@ -22,7 +22,7 @@ class MQTStatevectorSimulatorTest(unittest.TestCase):
 
     def test_statevector_output(self):
         """Test final state vector for single circuit run."""
-        result = execute(self.q_circuit, backend=self.backend).result()
+        result = self.backend.run(self.q_circuit).result()
         assert result.success
         actual = result.get_statevector()
 
@@ -35,7 +35,7 @@ class MQTStatevectorSimulatorTest(unittest.TestCase):
     def test_statevector_output_pairwise(self):
         """Test final state vector for single circuit run."""
         mode = "pairwise_recursive"
-        result = execute(self.q_circuit, backend=self.backend, mode=mode).result()
+        result = self.backend.run(self.q_circuit, mode=mode).result()
         assert result.success
         actual = result.get_statevector()
 

--- a/test/python/unitarysimulator/test_unitary_simulator.py
+++ b/test/python/unitarysimulator/test_unitary_simulator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import unittest
 
 import numpy as np
-from qiskit import QuantumCircuit, execute
+from qiskit import QuantumCircuit
 
 from mqt.ddsim.unitarysimulator import UnitarySimulatorBackend
 
@@ -20,12 +20,12 @@ class MQTUnitarySimulatorTest(unittest.TestCase):
         self.non_zeros_in_bell_circuit = 16
 
     def test_unitary_simulator_sequential_mode(self):
-        result = execute(self.circuit, self.backend, mode="sequential").result()
+        result = self.backend.run(self.circuit, mode="sequential").result()
         assert result.success
         print(result.get_unitary())
         assert np.count_nonzero(result.get_unitary()) == self.non_zeros_in_bell_circuit
 
     def test_unitary_simulator_recursive_mode(self):
-        result = execute(self.circuit, self.backend, mode="recursive").result()
+        result = self.backend.run(self.circuit, mode="recursive").result()
         assert result.success
         assert np.count_nonzero(result.get_unitary()) == self.non_zeros_in_bell_circuit


### PR DESCRIPTION
## Description

This PR works around some of the newly introduced deprecation warnings in Qiskit 0.46.0.
Most notable, the deprecation of the `execute` method.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
