### PR TITLE
👽 adjust to latest mqt-core changes

### DIFF
--- a/apps/noise_aware.cpp
+++ b/apps/noise_aware.cpp
@@ -113,8 +113,7 @@ int main(int argc, char** argv) { // NOLINT(bugprone-exception-escape)
         auto ddsim = std::make_unique<DeterministicNoiseSimulator<>>(std::move(quantumComputation), vm["noise_effects"].as<std::string>(),
                                                                      vm["noise_prob"].as<double>(),
                                                                      noiseProbT1,
-                                                                     vm["noise_prob_multi"].as<double>(),
-                                                                     vm.count("unoptimized_sim"), vm["seed"].as<std::size_t>());
+                                                                     vm["noise_prob_multi"].as<double>(), vm["seed"].as<std::size_t>());
 
         auto t1 = std::chrono::steady_clock::now();
 

--- a/src/DeterministicNoiseSimulator.cpp
+++ b/src/DeterministicNoiseSimulator.cpp
@@ -17,9 +17,7 @@ dd::SparsePVecStrKeys DeterministicNoiseSimulator<Config>::deterministicSimulate
             noiseProbMultiQubit,
             ampDampingProbSingleQubit,
             ampDampingProbMultiQubit,
-            noiseEffects,
-            useDensityMatrixType,
-            sequentiallyApplyNoise);
+            noiseEffects);
 
     for (auto const& op: *qc) {
         Simulator<Config>::dd->garbageCollect();
@@ -39,7 +37,7 @@ dd::SparsePVecStrKeys DeterministicNoiseSimulator<Config>::deterministicSimulate
         auto operation = dd::getDD(op.get(), *Simulator<Config>::dd);
 
         // Applying the operation to the density matrix
-        Simulator<Config>::dd->applyOperationToDensity(rootEdge, operation, useDensityMatrixType);
+        Simulator<Config>::dd->applyOperationToDensity(rootEdge, operation);
 
         deterministicNoiseFunctionality.applyNoiseEffects(rootEdge, op);
     }

--- a/test/test_det_noise_sim.cpp
+++ b/test/test_det_noise_sim.cpp
@@ -226,32 +226,6 @@ TEST(DeterministicNoiseSimTest, TestFunctionsOptimized) {
     EXPECT_EQ(ddsim->countNodesFromRoot(), 23);
 }
 
-TEST(DeterministicNoiseSimTest, TestFunctionsUnOptimized) {
-    auto quantumComputation = detGetAdder4Circuit();
-    auto ddsim              = std::make_unique<DeterministicNoiseSimulator<>>(std::move(quantumComputation), std::string("APD"), 0.01, 0.02, 1, true);
-    auto m                  = ddsim->deterministicSimulate();
-
-    EXPECT_EQ(ddsim->getNumberOfQubits(), 4);
-    EXPECT_EQ(ddsim->getActiveNodeCount(), 29);
-    EXPECT_EQ(ddsim->getMaxNodeCount(), 58);
-    EXPECT_EQ(ddsim->getMaxMatrixNodeCount(), 0);
-    EXPECT_EQ(ddsim->getMatrixActiveNodeCount(), 0);
-    EXPECT_EQ(ddsim->countNodesFromRoot(), 30);
-}
-
-TEST(DeterministicNoiseSimTest, TestingSimulatorFunctionality) {
-    auto quantumComputation = detGetAdder4Circuit();
-    auto ddsim              = std::make_unique<DeterministicNoiseSimulator<>>(std::move(quantumComputation), std::string("APD"), 0.01, 0.02, 1, true);
-    auto m                  = ddsim->deterministicSimulate();
-
-    EXPECT_EQ(ddsim->getNumberOfQubits(), 4);
-    EXPECT_EQ(ddsim->getActiveNodeCount(), 29);
-    EXPECT_EQ(ddsim->getMaxNodeCount(), 58);
-    EXPECT_EQ(ddsim->getMaxMatrixNodeCount(), 0);
-    EXPECT_EQ(ddsim->getMatrixActiveNodeCount(), 0);
-    EXPECT_EQ(ddsim->countNodesFromRoot(), 30);
-}
-
 TEST(DeterministicNoiseSimTest, sampleFromProbabilityMap1) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2);
     quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::X);


### PR DESCRIPTION
## Description

This PR adjust the codebase to the latest changes from mqt-core (specifically cda-tum/mqt-core#491).
Note that this merely applies the minimal changes necessary to run the project with the latest version.
A proper cleanup of the noise-aware simulators is scheduled to arrive with #321.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
