### PR TITLE
⬆️ update scikit-build-core to 0.8.1

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ nox.options.sessions = ["lint", "tests"]
 PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
 BUILD_REQUIREMENTS = [
-    "scikit-build-core[pyproject]>=0.6.1",
+    "scikit-build-core[pyproject]>=0.8.1",
     "setuptools_scm>=7",
     "pybind11>=2.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.6.1", "setuptools-scm>=7", "pybind11>=2.11"]
+requires = ["scikit-build-core>=0.8.1", "setuptools-scm>=7", "pybind11>=2.11"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -86,8 +86,8 @@ minimum-version = "0.6.1"
 wheel.install-dir = "mqt/ddsim"
 
 # Set required CMake and Ninja versions
-cmake.minimum-version = "3.19"
-ninja.minimum-version = "1.10"
+cmake.version = ">=3.19"
+ninja.version = ">=1.10"
 
 # Setuptools-style build caching in a local directory
 build-dir = "build/{wheel_tag}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ Discussions = "https://github.com/cda-tum/mqt-ddsim/discussions"
 
 [tool.scikit-build]
 # Protect the configuration against future changes in scikit-build-core
-minimum-version = "0.6.1"
+minimum-version = "0.8.1"
 
 # Set the wheel install directory
 wheel.install-dir = "mqt/ddsim"

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -1,4 +1,4 @@
-scikit-build-core==0.6.1
+scikit-build-core==0.8.1
 setuptools-scm==7.0.0
 pybind11==2.11.0
 pytest==7.0.0


### PR DESCRIPTION
## Description

This updates the minimum scikit-build-core version of the project to `0.8.1` based on the bugfix for Ninja installs on Windows that landed as part of that release. See https://github.com/scikit-build/scikit-build-core/issues/629 for details.

In addition to updating the package version, this PR also updates the corresponding configuration to use the latest version of the settings.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
