### PR TITLE
🩹 Qiskit now transpiles gates correctly

### DIFF
--- a/test/python/test_target.py
+++ b/test/python/test_target.py
@@ -31,10 +31,7 @@ def test_transpilation_preserves_1q_0p_target_gates(target: Target, gate: str):
     getattr(qc, gate)(0)
     qc_transpiled = transpile(qc, target=target)
     assert len(qc_transpiled.data) == 1
-    # A bug in the Qiskit compiler unrolls gates even though they are in the native gate-set.
-    # See https://github.com/Qiskit/qiskit/issues/10568
-    # As a result, the following check fails as of qiskit-terra 0.25:
-    # assert qc_transpiled.data[0][0].name == gate
+    assert qc_transpiled.data[0][0].name == gate
 
 
 @pytest.mark.parametrize("gate", ["rx", "ry", "rz", "p"])


### PR DESCRIPTION
## Description

This PR removes the test workaround for the Qiskit target support. Qiskit no longer unnecessarily transpiles gates that are natively supported.

Fixes #290 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
