### PR TITLE
✨ Stripping DDs of their identity

### DIFF
--- a/include/DeterministicNoiseSimulator.hpp
+++ b/include/DeterministicNoiseSimulator.hpp
@@ -62,7 +62,7 @@ public:
     }
 
     std::map<std::string, std::size_t> measureAllNonCollapsing(std::size_t shots) override {
-        return sampleFromProbabilityMap(rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold), shots);
+        return sampleFromProbabilityMap(rootEdge.getSparseProbabilityVectorStrKeys(getNumberOfQubits(), measurementThreshold), shots);
     }
 
     void initializeSimulation(std::size_t nQubits) override;

--- a/src/HybridSchrodingerFeynmanSimulator.cpp
+++ b/src/HybridSchrodingerFeynmanSimulator.cpp
@@ -50,7 +50,7 @@ qc::VectorDD HybridSchrodingerFeynmanSimulator<Config>::simulateSlicing(std::uni
         sliceDD->garbageCollect();
     }
 
-    auto result = sliceDD->kronecker(upper.edge, lower.edge, false);
+    auto result = sliceDD->kronecker(upper.edge, lower.edge, lower.nqubits, false);
     sliceDD->incRef(result);
 
     return result;
@@ -104,16 +104,19 @@ bool HybridSchrodingerFeynmanSimulator<Config>::Slice::apply(std::unique_ptr<dd:
             isSplitOp          = true;
             const bool control = getNextControl();
             for (const auto& c: opControls) {
-                sliceDD->decRef(edge); // TODO incref and decref could be integrated in delete edge
-                edge = sliceDD->deleteEdge(edge, static_cast<dd::Qubit>(c.qubit), control ? (c.type == qc::Control::Type::Pos ? 0 : 1) : (c.type == qc::Control::Type::Pos ? 1 : 0));
+                auto tmp = edge;
+                edge     = sliceDD->deleteEdge(edge, static_cast<dd::Qubit>(c.qubit), control ? (c.type == qc::Control::Type::Pos ? 0 : 1) : (c.type == qc::Control::Type::Pos ? 1 : 0));
+                // TODO incref and decref could be integrated in delete edge
                 sliceDD->incRef(edge);
+                sliceDD->decRef(tmp);
             }
         } else if (targetInSplit) { // target slice for split or operation in split
             const auto&           param = op->getParameter();
             qc::StandardOperation newOp(nqubits, opControls, opTargets, op->getType(), param, start);
-            sliceDD->decRef(edge);
-            edge = sliceDD->multiply(dd::getDD(&newOp, *sliceDD), edge, static_cast<dd::Qubit>(start));
+            auto                  tmp = edge;
+            edge                      = sliceDD->multiply(dd::getDD(&newOp, *sliceDD), edge, static_cast<dd::Qubit>(start));
             sliceDD->incRef(edge);
+            sliceDD->decRef(tmp);
         }
     } else {
         throw std::invalid_argument("Only StandardOperations are supported for now.");

--- a/src/HybridSchrodingerFeynmanSimulator.cpp
+++ b/src/HybridSchrodingerFeynmanSimulator.cpp
@@ -133,7 +133,7 @@ std::map<std::string, std::size_t> HybridSchrodingerFeynmanSimulator<Config>::si
     auto splitQubit = static_cast<qc::Qubit>(nqubits / 2);
     if (mode == Mode::DD) {
         simulateHybridTaskflow(splitQubit);
-        return Simulator<Config>::measureAllNonCollapsing(shots);
+        return CircuitSimulator<Config>::measureAllNonCollapsing(shots);
     }
     simulateHybridAmplitudes(splitQubit);
 

--- a/src/ShorFastSimulator.cpp
+++ b/src/ShorFastSimulator.cpp
@@ -223,7 +223,7 @@ dd::mEdge ShorFastSimulator<Config>::limitTo(std::uint64_t a) {
 
     for (std::uint32_t p = 1; p < requiredBits + 1; p++) {
         if (((a >> p) & 1U) > 0) {
-            edges[0] = Simulator<Config>::dd->makeIdent(0, static_cast<dd::Qubit>(p - 1));
+            edges[0] = Simulator<Config>::dd->makeIdent();
             edges[3] = f;
         } else {
             edges[0] = f;

--- a/src/ShorSimulator.cpp
+++ b/src/ShorSimulator.cpp
@@ -255,7 +255,7 @@ dd::mEdge ShorSimulator<Config>::limitTo(std::uint64_t a) {
 
     for (std::uint32_t p = 1; p < requiredBits + 1; p++) {
         if (((a >> p) & 1U) > 0) {
-            edges[0] = Simulator<Config>::dd->makeIdent(0, static_cast<dd::Qubit>(p - 1));
+            edges[0] = Simulator<Config>::dd->makeIdent();
             edges[3] = f;
         } else {
             edges[0] = f;
@@ -349,7 +349,7 @@ dd::mEdge ShorSimulator<Config>::addConstMod(std::uint64_t a) {
 
 template<class Config>
 void ShorSimulator<Config>::uAEmulate(std::uint64_t a, std::int32_t q) {
-    const dd::mEdge limit = Simulator<Config>::dd->makeIdent(0, static_cast<dd::Qubit>(requiredBits - 1));
+    const dd::mEdge limit = Simulator<Config>::dd->makeIdent();
 
     dd::mEdge                f = dd::mEdge::one();
     std::array<dd::mEdge, 4> edges{
@@ -411,7 +411,7 @@ void ShorSimulator<Config>::uAEmulate(std::uint64_t a, std::int32_t q) {
     for (auto i = static_cast<std::int32_t>(2 * requiredBits - 1); i >= 0; --i) {
         if (i == q) {
             edges[1] = edges[2] = dd::mEdge::zero();
-            edges[0]            = Simulator<Config>::dd->makeIdent(0, static_cast<dd::Qubit>(nQubits - static_cast<std::size_t>(i) - 2));
+            edges[0]            = Simulator<Config>::dd->makeIdent();
             edges[3]            = e;
             e                   = Simulator<Config>::dd->makeDDNode(static_cast<dd::Qubit>(nQubits - 1 - static_cast<std::size_t>(i)), edges, false);
         } else {

--- a/test/test_det_noise_sim.cpp
+++ b/test/test_det_noise_sim.cpp
@@ -42,7 +42,7 @@ TEST(DeterministicNoiseSimTest, TestingBarrierGate) {
     auto         ddsim                = std::make_unique<DeterministicNoiseSimulator>(std::move(quantumComputation), std::string("A"), 0, 0, 1);
     double const measurementThreshold = 0.01;
     ddsim->simulate(1);
-    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold);
+    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(ddsim->getNumberOfQubits(), measurementThreshold);
 
     ASSERT_EQ(ddsim->getNumberOfOps(), 2);
     ASSERT_EQ(m.find("01")->second, 1);
@@ -96,22 +96,17 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAPDWithSimulate) {
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
-    const auto tolerance = 100;
-    EXPECT_NEAR(static_cast<double>(m.find("0000")->second), 969, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0001")->second), 1731, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0010")->second), 238, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0011")->second), 242, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0100")->second), 141, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0101")->second), 138, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0110")->second), 244, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0111")->second), 239, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1000")->second), 907, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1001")->second), 4145, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1010")->second), 235, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1011")->second), 262, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1101")->second), 184, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1110")->second), 116, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1111")->second), 110, tolerance);
+    const auto expectedEntries = std::array{
+            "0000", "0001", "0010", "0011", "0100", "0101", "0110", "0111",
+            "1000", "1001", "1010", "1011", "1101", "1110", "1111"};
+    const auto expectedValues = std::array{969, 1731, 238, 242, 141, 138, 244, 239, 907, 4145, 235, 262, 184, 116, 110};
+    const auto tolerance      = 100;
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(static_cast<double>(m.at(expectedEntries.at(i))), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, SimulateAdder4TrackD) {
@@ -120,21 +115,22 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4TrackD) {
 
     double const measurementThreshold = 0.01;
     ddsim->simulate(1);
-    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold);
+    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(ddsim->getNumberOfQubits(), measurementThreshold);
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
-    const double tolerance = 1e-10;
-    EXPECT_NEAR(m.find("0000")->second, 0.0332328704931, tolerance);
-    EXPECT_NEAR(m.find("0001")->second, 0.0683938280189, tolerance);
-    EXPECT_NEAR(m.find("0011")->second, 0.0117061689898, tolerance);
-    EXPECT_NEAR(m.find("0100")->second, 0.0129643065735, tolerance);
-    EXPECT_NEAR(m.find("0101")->second, 0.0107812802908, tolerance);
-    EXPECT_NEAR(m.find("0111")->second, 0.0160082331009, tolerance);
-    EXPECT_NEAR(m.find("1000")->second, 0.0328434857577, tolerance);
-    EXPECT_NEAR(m.find("1001")->second, 0.7370101351171, tolerance);
-    EXPECT_NEAR(m.find("1011")->second, 0.0186346925411, tolerance);
-    EXPECT_NEAR(m.find("1101")->second, 0.0275086747656, tolerance);
+    const auto expectedEntries = std::array{
+            "0000", "0001", "0011", "0100", "0101", "0111", "1000", "1001", "1011", "1101"};
+    const auto expectedValues = std::array{
+            0.0332328704931, 0.0683938280189, 0.0117061689898, 0.0129643065735, 0.0107812802908,
+            0.0160082331009, 0.0328434857577, 0.7370101351171, 0.0186346925411, 0.0275086747656};
+    const auto tolerance = 1e-10;
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(m.at(expectedEntries.at(i)), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAPD) {
@@ -143,26 +139,25 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAPD) {
 
     double const measurementThreshold = 0.01;
     ddsim->simulate(1);
-    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold);
+    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(ddsim->getNumberOfQubits(), measurementThreshold);
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
-    const double tolerance = 1e-10;
-    EXPECT_NEAR(m.find("0000")->second, 0.0969332192741, tolerance);
-    EXPECT_NEAR(m.find("0001")->second, 0.1731941264570, tolerance);
-    EXPECT_NEAR(m.find("0010")->second, 0.0238203475524, tolerance);
-    EXPECT_NEAR(m.find("0011")->second, 0.0242454336917, tolerance);
-    EXPECT_NEAR(m.find("0100")->second, 0.0141409660985, tolerance);
-    EXPECT_NEAR(m.find("0101")->second, 0.0138062113213, tolerance);
-    EXPECT_NEAR(m.find("0110")->second, 0.0244576087400, tolerance);
-    EXPECT_NEAR(m.find("0111")->second, 0.0239296920989, tolerance);
-    EXPECT_NEAR(m.find("1000")->second, 0.0907888041538, tolerance);
-    EXPECT_NEAR(m.find("1001")->second, 0.4145855071998, tolerance);
-    EXPECT_NEAR(m.find("1010")->second, 0.0235097990017, tolerance);
-    EXPECT_NEAR(m.find("1011")->second, 0.0262779844799, tolerance);
-    EXPECT_NEAR(m.find("1101")->second, 0.0184033482066, tolerance);
-    EXPECT_NEAR(m.find("1110")->second, 0.0116282811276, tolerance);
-    EXPECT_NEAR(m.find("1111")->second, 0.0110373166627, tolerance);
+    const auto expectedEntries = std::array{
+            "0000", "0001", "0010", "0011", "0100", "0101", "0110", "0111",
+            "1000", "1001", "1010", "1011", "1101", "1110", "1111"};
+    const auto expectedValues = std::array{
+            0.0969332192741, 0.1731941264570, 0.0238203475524, 0.0242454336917,
+            0.0141409660985, 0.0138062113213, 0.0244576087400, 0.0239296920989,
+            0.0907888041538, 0.4145855071998, 0.0235097990017, 0.0262779844799,
+            0.0184033482066, 0.0116282811276, 0.0110373166627};
+    const auto tolerance = 1e-10;
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(m.at(expectedEntries.at(i)), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAP) {
@@ -171,13 +166,21 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAP) {
 
     double const measurementThreshold = 0.01;
     ddsim->simulate(1);
-    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold);
+    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(ddsim->getNumberOfQubits(), measurementThreshold);
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
-    const double tolerance = 1e-10;
-    EXPECT_NEAR(m.find("0001")->second, 0.03008702498522842, tolerance);
-    EXPECT_NEAR(m.find("1001")->second, 0.9364832248561167, tolerance);
+    const auto expectedEntries = std::array{
+            "0001", "1001"};
+    const auto expectedValues = std::array{
+            0.03008702498522842, 0.9364832248561167};
+    const auto tolerance = 1e-10;
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(m.at(expectedEntries.at(i)), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, SimulateRunWithBadParameters) {
@@ -191,22 +194,23 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAPDCustomProb) {
 
     double const measurementThreshold = 0.01;
     ddsim->simulate(1);
-    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold);
+    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(ddsim->getNumberOfQubits(), measurementThreshold);
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
-    const double tolerance = 1e-10;
-    EXPECT_NEAR(m.find("0000")->second, 0.0616548044047, tolerance);
-    EXPECT_NEAR(m.find("0001")->second, 0.1487734834937, tolerance);
-    EXPECT_NEAR(m.find("0010")->second, 0.0155601736851, tolerance);
-    EXPECT_NEAR(m.find("0011")->second, 0.0166178042857, tolerance);
-    EXPECT_NEAR(m.find("0110")->second, 0.0301651684817, tolerance);
-    EXPECT_NEAR(m.find("0111")->second, 0.0301853251959, tolerance);
-    EXPECT_NEAR(m.find("1000")->second, 0.0570878674208, tolerance);
-    EXPECT_NEAR(m.find("1001")->second, 0.5519250213313, tolerance);
-    EXPECT_NEAR(m.find("1010")->second, 0.0157508473593, tolerance);
-    EXPECT_NEAR(m.find("1011")->second, 0.0187340765889, tolerance);
-    EXPECT_NEAR(m.find("1101")->second, 0.0132640682125, tolerance);
+    const auto expectedEntries = std::array{
+            "0000", "0001", "0010", "0011", "0110", "0111", "1000", "1001", "1010", "1011", "1101"};
+    const auto expectedValues = std::array{
+            0.0616548044047, 0.1487734834937, 0.0155601736851, 0.0166178042857, 0.0301651684817,
+            0.0301853251959, 0.0570878674208, 0.5519250213313, 0.0157508473593, 0.0187340765889,
+            0.0132640682125};
+    const auto tolerance = 1e-10;
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(m.at(expectedEntries.at(i)), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAPDWithShots) {
@@ -217,12 +221,17 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4TrackAPDWithShots) {
     auto m = ddsim->simulate(10000);
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
+    const auto expectedEntries = std::array{
+            "0000", "0001", "1000", "1001"};
+    const auto expectedValues = std::array{
+            616, 1487, 570, 5519};
     const std::size_t tolerance = 500;
-
-    EXPECT_NEAR(static_cast<double>(m.find("0000")->second), 616, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0001")->second), 1487, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1000")->second), 570, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1001")->second), 5519, tolerance);
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(static_cast<double>(m.at(expectedEntries.at(i))), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, SimulateAdder4NoNoise1) {
@@ -231,11 +240,14 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4NoNoise1) {
 
     double const measurementThreshold = 0.01;
     ddsim->simulate(1);
-    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(measurementThreshold);
+    auto m = ddsim->rootEdge.getSparseProbabilityVectorStrKeys(ddsim->getNumberOfQubits(), measurementThreshold);
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
     const double tolerance = 1e-10;
+    if (m.count("1001") == 0) {
+        FAIL() << "Expected entry 1001 not found in result";
+    }
     EXPECT_NEAR(m.find("1001")->second, 1, tolerance);
 }
 
@@ -249,6 +261,9 @@ TEST(DeterministicNoiseSimTest, SimulateAdder4NoNoise2) {
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
     const double tolerance = 1e-10;
+    if (m.count("1001") == 0) {
+        FAIL() << "Expected entry 1001 not found in result";
+    }
     EXPECT_NEAR(static_cast<double>(m.find("1001")->second), static_cast<double>(shots), tolerance);
 }
 
@@ -273,11 +288,17 @@ TEST(DeterministicNoiseSimTest, TestSimulateInterface) {
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
+    const auto expectedEntries = std::array{
+            "0000", "0001", "1000", "1001"};
+    const auto expectedValues = std::array{
+            616, 1487, 570, 5519};
     const double tolerance = 500;
-    EXPECT_NEAR(static_cast<double>(m.find("0000")->second), 616, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0001")->second), 1487, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1000")->second), 570, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1001")->second), 5519, tolerance);
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(static_cast<double>(m.at(expectedEntries.at(i))), expectedValues.at(i), tolerance);
+    }
 }
 
 TEST(DeterministicNoiseSimTest, TestSimulateInterfaceWithMeasurments) {
@@ -294,9 +315,15 @@ TEST(DeterministicNoiseSimTest, TestSimulateInterfaceWithMeasurments) {
 
     std::cout << std::setw(2) << nlohmann::json(m) << "\n";
 
+    const auto expectedEntries = std::array{
+            "0000", "0001", "1000", "1001"};
+    const auto expectedValues = std::array{
+            616, 1487, 570, 5519};
     const double tolerance = 500;
-    EXPECT_NEAR(static_cast<double>(m.find("0000")->second), 616, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("0001")->second), 1487, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1000")->second), 570, tolerance);
-    EXPECT_NEAR(static_cast<double>(m.find("1001")->second), 5519, tolerance);
+    for (std::size_t i = 0; i < expectedEntries.size(); ++i) {
+        if (m.count(expectedEntries.at(i)) == 0) {
+            FAIL() << "Expected entry " << expectedEntries.at(i) << " not found in result";
+        }
+        EXPECT_NEAR(static_cast<double>(m.at(expectedEntries.at(i))), expectedValues.at(i), tolerance);
+    }
 }

--- a/test/test_unitary_sim.cpp
+++ b/test/test_unitary_sim.cpp
@@ -13,13 +13,13 @@ TEST(UnitarySimTest, ConstructSimpleCircuitSequential) {
     UnitarySimulator ddsim(std::move(quantumComputation), UnitarySimulator<>::Mode::Sequential);
     ASSERT_NO_THROW(ddsim.construct());
     const auto& e = ddsim.getConstructedDD();
-    EXPECT_TRUE(e.p->e[0].p->isIdentity());
-    EXPECT_TRUE(e.p->e[1].p->isIdentity());
+    EXPECT_TRUE(e.p->e[0].isIdentity());
+    EXPECT_TRUE(e.p->e[1].isIdentity());
     auto finalNodes = ddsim.getFinalNodeCount();
-    EXPECT_EQ(finalNodes, 6);
+    EXPECT_EQ(finalNodes, 4);
     auto maxNodes         = ddsim.getMaxNodeCount();
     auto constructionTime = ddsim.getConstructionTime();
-    std::cout << "Construction took " << constructionTime << "s, requiring a maximum of " << maxNodes << " nodes" << std::endl;
+    std::cout << "Construction took " << constructionTime << "s, requiring a maximum of " << maxNodes << " nodes\n";
 }
 
 TEST(UnitarySimTest, ConstructSimpleCircuitRecursive) {
@@ -30,13 +30,13 @@ TEST(UnitarySimTest, ConstructSimpleCircuitRecursive) {
     UnitarySimulator ddsim(std::move(quantumComputation), UnitarySimulator<>::Mode::Recursive);
     ASSERT_NO_THROW(ddsim.construct());
     const auto& e = ddsim.getConstructedDD();
-    EXPECT_TRUE(e.p->e[0].p->isIdentity());
-    EXPECT_TRUE(e.p->e[1].p->isIdentity());
+    EXPECT_TRUE(e.p->e[0].isIdentity());
+    EXPECT_TRUE(e.p->e[1].isIdentity());
     auto finalNodes = ddsim.getFinalNodeCount();
-    EXPECT_EQ(finalNodes, 6);
+    EXPECT_EQ(finalNodes, 4);
     auto maxNodes         = ddsim.getMaxNodeCount();
     auto constructionTime = ddsim.getConstructionTime();
-    std::cout << "Construction took " << constructionTime << "s, requiring a maximum of " << maxNodes << " nodes" << std::endl;
+    std::cout << "Construction took " << constructionTime << "s, requiring a maximum of " << maxNodes << " nodes\n";
 }
 
 TEST(UnitarySimTest, ConstructSimpleCircuitRecursiveWithSeed) {
@@ -47,8 +47,8 @@ TEST(UnitarySimTest, ConstructSimpleCircuitRecursiveWithSeed) {
     UnitarySimulator ddsim(std::move(quantumComputation), ApproximationInfo{}, 1337, UnitarySimulator<>::Mode::Recursive);
     ASSERT_NO_THROW(ddsim.construct());
     const auto& e = ddsim.getConstructedDD();
-    EXPECT_TRUE(e.p->e[0].p->isIdentity());
-    EXPECT_TRUE(e.p->e[1].p->isIdentity());
+    EXPECT_TRUE(e.p->e[0].isIdentity());
+    EXPECT_TRUE(e.p->e[1].isIdentity());
 }
 
 TEST(UnitarySimTest, NonStandardOperation) {


### PR DESCRIPTION
## Description

This PR pulls in the changes from cda-tum/mqt-core#358, which considerably changes the way matrix decision diagrams are represented. Particularly, any node resembling the identity is now eliminated and only implicitly represented.
This further compacts the representation of quantum gates and makes the identity the most compact it can be---a single terminal node.
The overall performance improvements are still to be evaluated. 

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
