### PR TITLE
♻️ Refactor based on changes to `Operation` class in mqt-core

### DIFF
--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -115,7 +115,7 @@ void CircuitSimulator<Config>::reset(qc::NonUnitaryOperation* nonUnitaryOp) {
         auto bit = Simulator<Config>::dd->measureOneCollapsing(Simulator<Config>::rootEdge, static_cast<dd::Qubit>(qubit), true, Simulator<Config>::mt);
         // apply an X operation whenever the measured result is one
         if (bit == '1') {
-            const auto x   = qc::StandardOperation(qc->getNqubits(), qubit, qc::X);
+            const auto x   = qc::StandardOperation(qubit, qc::X);
             auto       tmp = Simulator<Config>::dd->multiply(dd::getDD(&x, *Simulator<Config>::dd), Simulator<Config>::rootEdge);
             Simulator<Config>::dd->incRef(tmp);
             Simulator<Config>::dd->decRef(Simulator<Config>::rootEdge);

--- a/src/DeterministicNoiseSimulator.cpp
+++ b/src/DeterministicNoiseSimulator.cpp
@@ -24,7 +24,7 @@ void DeterministicNoiseSimulator::reset(qc::NonUnitaryOperation* nonUnitaryOp) {
     for (const auto& qubit: nonUnitaryOp->getTargets()) {
         auto const result = dd->measureOneCollapsing(rootEdge, static_cast<dd::Qubit>(qubit), mt);
         if (result == '1') {
-            const auto x         = qc::StandardOperation(getNumberOfQubits(), qubit, qc::X);
+            const auto x         = qc::StandardOperation(qubit, qc::X);
             const auto operation = dd::getDD(&x, *dd);
             rootEdge             = dd->applyOperationToDensity(rootEdge, operation);
         }

--- a/src/HybridSchrodingerFeynmanSimulator.cpp
+++ b/src/HybridSchrodingerFeynmanSimulator.cpp
@@ -112,9 +112,9 @@ bool HybridSchrodingerFeynmanSimulator<Config>::Slice::apply(std::unique_ptr<dd:
             }
         } else if (targetInSplit) { // target slice for split or operation in split
             const auto&           param = op->getParameter();
-            qc::StandardOperation newOp(nqubits, opControls, opTargets, op->getType(), param, start);
+            qc::StandardOperation newOp(opControls, opTargets, op->getType(), param);
             auto                  tmp = edge;
-            edge                      = sliceDD->multiply(dd::getDD(&newOp, *sliceDD), edge, static_cast<dd::Qubit>(start));
+            edge                      = sliceDD->multiply(dd::getDD(&newOp, *sliceDD), edge);
             sliceDD->incRef(edge);
             sliceDD->decRef(tmp);
         }

--- a/src/PathSimulator.cpp
+++ b/src/PathSimulator.cpp
@@ -106,7 +106,6 @@ template<class Config>
 std::map<std::string, std::size_t> PathSimulator<Config>::simulate(std::size_t shots) {
     // build task graph from simulation path
     constructTaskGraph();
-    //std::cout<< *qc << std::endl;
     /// Enable the following statements to generate a .dot file of the resulting taskflow
     //        std::ofstream ofs("taskflow.dot");
     //        taskflow.dump(ofs);
@@ -115,7 +114,7 @@ std::map<std::string, std::size_t> PathSimulator<Config>::simulate(std::size_t s
     executor.run(taskflow).wait();
 
     // measure resulting DD
-    return Simulator<Config>::measureAllNonCollapsing(shots);
+    return CircuitSimulator<Config>::measureAllNonCollapsing(shots);
 }
 
 template<class Config>

--- a/src/ShorFastSimulator.cpp
+++ b/src/ShorFastSimulator.cpp
@@ -314,7 +314,7 @@ dd::mEdge ShorFastSimulator<Config>::addConstMod(std::uint64_t a) {
 template<class Config>
 void ShorFastSimulator<Config>::applyGate(dd::GateMatrix matrix, dd::Qubit target) {
     numberOfOperations++;
-    const dd::Edge gate = Simulator<Config>::dd->makeGateDD(matrix, static_cast<dd::Qubit>(nQubits), target);
+    const dd::Edge gate = Simulator<Config>::dd->makeGateDD(matrix, target);
     const dd::Edge tmp  = Simulator<Config>::dd->multiply(gate, Simulator<Config>::rootEdge);
     Simulator<Config>::dd->incRef(tmp);
     Simulator<Config>::dd->decRef(Simulator<Config>::rootEdge);

--- a/src/ShorSimulator.cpp
+++ b/src/ShorSimulator.cpp
@@ -441,7 +441,7 @@ void ShorSimulator<Config>::applyGate(dd::GateMatrix matrix, dd::Qubit target, q
 
 template<class Config>
 void ShorSimulator<Config>::applyGate(dd::GateMatrix matrix, dd::Qubit target, const qc::Controls& controls) {
-    const dd::Edge gate = Simulator<Config>::dd->makeGateDD(matrix, static_cast<dd::Qubit>(nQubits), controls, target);
+    const dd::Edge gate = Simulator<Config>::dd->makeGateDD(matrix, controls, target);
     const dd::Edge tmp  = Simulator<Config>::dd->multiply(gate, Simulator<Config>::rootEdge);
     Simulator<Config>::dd->incRef(tmp);
     Simulator<Config>::dd->decRef(Simulator<Config>::rootEdge);

--- a/src/StochasticNoiseSimulator.cpp
+++ b/src/StochasticNoiseSimulator.cpp
@@ -81,7 +81,7 @@ void StochasticNoiseSimulator::runStochSimulationForId(std::size_t stochRun, qc:
                     for (const auto& qubit: qubits) {
                         const auto result = localDD->measureOneCollapsing(localRootEdge, static_cast<dd::Qubit>(qubits.at(qubit)), true, generator);
                         if (result == '1') {
-                            const auto x   = qc::StandardOperation(getNumberOfQubits(), qubit, qc::X);
+                            const auto x   = qc::StandardOperation(qubit, qc::X);
                             auto       tmp = localDD->multiply(dd::getDD(&x, *localDD), localRootEdge);
                             localDD->incRef(tmp);
                             localDD->decRef(localRootEdge);

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -9,7 +9,7 @@
 
 TEST(CircuitSimTest, SingleOneQubitGateOnTwoQubitCircuit) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::X);
+    quantumComputation->x(0);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
 
     ASSERT_EQ(ddsim.getNumberOfOps(), 1);
@@ -25,7 +25,7 @@ TEST(CircuitSimTest, SingleOneQubitGateOnTwoQubitCircuit) {
 
 TEST(CircuitSimTest, SingleOneQubitSingleShot) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::H);
+    quantumComputation->h(0);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
 
     ASSERT_EQ(ddsim.getNumberOfOps(), 1);
@@ -36,8 +36,8 @@ TEST(CircuitSimTest, SingleOneQubitSingleShot) {
 
 TEST(CircuitSimTest, SingleOneQubitSingleShot2) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2, 2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::H);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(2, 0, 0);
+    quantumComputation->h(0);
+    quantumComputation->measure(0, 0);
     std::cout << *quantumComputation << "\n";
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(), 1337);
 
@@ -49,9 +49,9 @@ TEST(CircuitSimTest, SingleOneQubitSingleShot2) {
 
 TEST(CircuitSimTest, SingleOneQubitMultiShots) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2, 2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::H);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(2, 0, 0);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::H);
+    quantumComputation->h(0);
+    quantumComputation->measure(0, 0);
+    quantumComputation->h(0);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
 
     ASSERT_EQ(ddsim.getNumberOfOps(), 3);
@@ -75,9 +75,9 @@ TEST(CircuitSimTest, BarrierStatement) {
 
 TEST(CircuitSimTest, ClassicControlledOp) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2, 2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::X);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(2, 0, 0);
-    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(2, 1, qc::X));
+    quantumComputation->x(0);
+    quantumComputation->measure(0, 0);
+    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(1, qc::X));
     quantumComputation->emplace_back<qc::ClassicControlledOperation>(op, quantumComputation->getCregs().at("c"), 1);
 
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
@@ -90,9 +90,9 @@ TEST(CircuitSimTest, ClassicControlledOp) {
 
 TEST(CircuitSimTest, ClassicControlledOpAsNop) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2, 2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::X);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(2, 0, 0);
-    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(2, 1, qc::X));
+    quantumComputation->x(0);
+    quantumComputation->measure(0, 0);
+    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(1, qc::X));
     quantumComputation->emplace_back<qc::ClassicControlledOperation>(op, quantumComputation->getCregs().at("c"), 0);
 
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
@@ -105,8 +105,8 @@ TEST(CircuitSimTest, ClassicControlledOpAsNop) {
 
 TEST(CircuitSimTest, DestructiveMeasurementAll) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 1, qc::H);
+    quantumComputation->h(0);
+    quantumComputation->h(1);
     CircuitSimulator ddsim(std::move(quantumComputation), 42);
     ddsim.simulate(1);
 
@@ -125,8 +125,8 @@ TEST(CircuitSimTest, DestructiveMeasurementAll) {
 
 TEST(CircuitSimTest, DestructiveMeasurementOne) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 0, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(2, 1, qc::H);
+    quantumComputation->h(0);
+    quantumComputation->h(1);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
     ddsim.simulate(1);
 
@@ -150,9 +150,9 @@ TEST(CircuitSimTest, DestructiveMeasurementOne) {
 
 TEST(CircuitSimTest, ApproximateByFidelity) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 0, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, qc::Controls{qc::Control{0}, qc::Control{1}}, 2, qc::X);
+    quantumComputation->h(0);
+    quantumComputation->h(1);
+    quantumComputation->mcx(qc::Controls{qc::Control{0}, qc::Control{1}}, 2);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
     std::cout << ddsim.getActiveNodeCount() << "\n";
     ddsim.simulate(1);
@@ -166,9 +166,9 @@ TEST(CircuitSimTest, ApproximateByFidelity) {
 
 TEST(CircuitSimTest, ApproximateBySampling) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 0, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, qc::Controls{qc::Control{0}, qc::Control{1}}, 2, qc::X);
+    quantumComputation->h(0);
+    quantumComputation->h(1);
+    quantumComputation->mcx(qc::Controls{qc::Control{0}, qc::Control{1}}, 2);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven));
     ddsim.simulate(1);
 
@@ -191,12 +191,12 @@ TEST(CircuitSimTest, ApproximationByMemoryInSimulator) {
 
 TEST(CircuitSimTest, ApproximationByFidelityInSimulator) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 0, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, qc::Controls{qc::Control{0}, qc::Control{1}}, 2, qc::X);
+    quantumComputation->h(0);
+    quantumComputation->h(1);
+    quantumComputation->mcx(qc::Controls{qc::Control{0}, qc::Control{1}}, 2);
 
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 1, qc::I); // some dummy operations
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 1, qc::I);
+    quantumComputation->i(1); // some dummy operations
+    quantumComputation->i(1);
 
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(0.3, 1, ApproximationInfo::FidelityDriven));
     ddsim.simulate(1);
@@ -225,9 +225,9 @@ TEST(CircuitSimTest, GRCS4x4Test) {
 
 TEST(CircuitSimTest, TestingProperties) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 0, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, qc::Controls{qc::Control{0}, qc::Control{1}}, 2, qc::X);
+    quantumComputation->h(0);
+    quantumComputation->h(1);
+    quantumComputation->mcx(qc::Controls{qc::Control{0}, qc::Control{1}}, 2);
     CircuitSimulator ddsim(std::move(quantumComputation), ApproximationInfo(1, 1, ApproximationInfo::FidelityDriven), 1);
     ddsim.simulate(1);
 

--- a/test/test_det_noise_sim.cpp
+++ b/test/test_det_noise_sim.cpp
@@ -67,7 +67,7 @@ TEST(DeterministicNoiseSimTest, ClassicControlledOp) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(2, 2);
     quantumComputation->x(0);
     quantumComputation->measure(0, 0);
-    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(2, 1, qc::X));
+    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(1, qc::X));
     auto                           classicalRegister = std::pair<std::size_t, std::size_t>(0, 1);
     quantumComputation->emplace_back<qc::ClassicControlledOperation>(op, classicalRegister, 1);
     quantumComputation->measure(0, 0);

--- a/test/test_stoch_noise_sim.cpp
+++ b/test/test_stoch_noise_sim.cpp
@@ -137,7 +137,7 @@ TEST(StochNoiseSimTest, CheckQubitOrder) {
         quantumComputation->measure(i, i);
     }
 
-    StochasticNoiseSimulator ddsim(std::move(quantumComputation), {}, 42U, "APD", 0.02);
+    StochasticNoiseSimulator ddsim(std::move(quantumComputation), {}, 41U, "APD", 0.02);
 
     const auto m = ddsim.simulate(1000);
 

--- a/test/test_stoch_noise_sim.cpp
+++ b/test/test_stoch_noise_sim.cpp
@@ -110,7 +110,7 @@ TEST(StochNoiseSimTest, SimulateClassicControlledOpWithError) {
     quantumComputation->x(0);
     quantumComputation->measure(0, 0);
     quantumComputation->h(0);
-    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(2, 1, qc::X));
+    std::unique_ptr<qc::Operation> op(new qc::StandardOperation(1, qc::X));
     auto                           classicalRegister = std::pair<std::size_t, std::size_t>(0, 1);
     quantumComputation->emplace_back<qc::ClassicControlledOperation>(op, classicalRegister, 1);
 
@@ -137,7 +137,7 @@ TEST(StochNoiseSimTest, CheckQubitOrder) {
         quantumComputation->measure(i, i);
     }
 
-    StochasticNoiseSimulator ddsim(std::move(quantumComputation), {}, 41U, "APD", 0.02);
+    StochasticNoiseSimulator ddsim(std::move(quantumComputation), {}, 42U, "APD", 0.02);
 
     const auto m = ddsim.simulate(1000);
 

--- a/test/test_unitary_sim.cpp
+++ b/test/test_unitary_sim.cpp
@@ -7,9 +7,9 @@ using namespace qc::literals;
 
 TEST(UnitarySimTest, ConstructSimpleCircuitSequential) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2_pc, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2_pc, 0, qc::H);
+    quantumComputation->h(2);
+    quantumComputation->ch(2, 1);
+    quantumComputation->ch(2, 0);
     UnitarySimulator ddsim(std::move(quantumComputation), UnitarySimulator<>::Mode::Sequential);
     ASSERT_NO_THROW(ddsim.construct());
     const auto& e = ddsim.getConstructedDD();
@@ -24,9 +24,9 @@ TEST(UnitarySimTest, ConstructSimpleCircuitSequential) {
 
 TEST(UnitarySimTest, ConstructSimpleCircuitRecursive) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2_pc, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2_pc, 0, qc::H);
+    quantumComputation->h(2);
+    quantumComputation->ch(2, 1);
+    quantumComputation->ch(2, 0);
     UnitarySimulator ddsim(std::move(quantumComputation), UnitarySimulator<>::Mode::Recursive);
     ASSERT_NO_THROW(ddsim.construct());
     const auto& e = ddsim.getConstructedDD();
@@ -41,9 +41,9 @@ TEST(UnitarySimTest, ConstructSimpleCircuitRecursive) {
 
 TEST(UnitarySimTest, ConstructSimpleCircuitRecursiveWithSeed) {
     auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2_pc, 1, qc::H);
-    quantumComputation->emplace_back<qc::StandardOperation>(3, 2_pc, 0, qc::H);
+    quantumComputation->h(2);
+    quantumComputation->ch(2, 1);
+    quantumComputation->ch(2, 0);
     UnitarySimulator ddsim(std::move(quantumComputation), ApproximationInfo{}, 1337, UnitarySimulator<>::Mode::Recursive);
     ASSERT_NO_THROW(ddsim.construct());
     const auto& e = ddsim.getConstructedDD();
@@ -52,12 +52,12 @@ TEST(UnitarySimTest, ConstructSimpleCircuitRecursiveWithSeed) {
 }
 
 TEST(UnitarySimTest, NonStandardOperation) {
-    auto quantumComputation = std::make_unique<qc::QuantumComputation>(1);
-    quantumComputation->emplace_back<qc::StandardOperation>(1, 0, qc::H);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(1, 0, 0);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(1, 0, qc::Barrier);
-    quantumComputation->emplace_back<qc::StandardOperation>(1, 0, qc::H);
-    quantumComputation->emplace_back<qc::NonUnitaryOperation>(1, 0, 0);
+    auto quantumComputation = std::make_unique<qc::QuantumComputation>(1, 1);
+    quantumComputation->h(0);
+    quantumComputation->measure(0, 0);
+    quantumComputation->barrier(0);
+    quantumComputation->h(0);
+    quantumComputation->measure(0, 0);
 
     UnitarySimulator ddsim(std::move(quantumComputation));
     EXPECT_TRUE(ddsim.getMode() == UnitarySimulator<>::Mode::Recursive);


### PR DESCRIPTION
## Description

This PR updates DDSIM to the latest mqt-core version that has dropped some long-overdue parameters of functions and members of classes. In particular, the operation classes no longer need the total number of qubits and the starting qubit in order to properly function.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
