### PR TITLE
✨ Adopt `uv` in CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -33,7 +33,7 @@ flag_management:
     - name: python
       paths:
         - "src/mqt/**/*.py"
-      after_n_builds: 3
+      after_n_builds: 12
       statuses:
         - type: project
           threshold: 0.5%

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shutil
 import sys
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,9 @@ import nox
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
+nox.needs_version = ">=2024.3.2"
+nox.options.default_venv_backend = "uv|virtualenv"
 
 nox.options.sessions = ["lint", "tests"]
 
@@ -49,6 +53,11 @@ def _run_tests(
     if os.environ.get("CI", None) and sys.platform == "win32":
         env["SKBUILD_CMAKE_ARGS"] = "-T ClangCL"
 
+    if shutil.which("cmake") is None and shutil.which("cmake3") is None:
+        session.install("cmake")
+    if shutil.which("ninja") is None:
+        session.install("ninja")
+
     _extras = ["test", *extras]
     if "--cov" in posargs:
         _extras.append("coverage")
@@ -66,29 +75,27 @@ def tests(session: nox.Session) -> None:
     _run_tests(session)
 
 
-@nox.session()
+@nox.session(reuse_venv=True, venv_backend="uv")
 def minimums(session: nox.Session) -> None:
     """Test the minimum versions of dependencies."""
     _run_tests(
         session,
-        install_args=["--constraint=test/python/constraints.txt"],
+        install_args=["--resolution=lowest-direct"],
         run_args=["-Wdefault"],
+        extras=["qiskit", "evaluation"],
     )
-    session.run("pip", "list")
+    session.run("uv", "pip", "list")
 
 
 @nox.session(reuse_venv=True)
 def docs(session: nox.Session) -> None:
-    """Build the docs. Pass "--serve" to serve. Pass "-b linkcheck" to check links."""
+    """Build the docs. Use "--non-interactive" to avoid serving. Pass "-b linkcheck" to check links."""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--serve", action="store_true", help="Serve after building")
     parser.add_argument("-b", dest="builder", default="html", help="Build target (default: html)")
     args, posargs = parser.parse_known_args(session.posargs)
 
-    if args.builder != "html" and args.serve:
-        session.error("Must not specify non-HTML builder with --serve")
-
-    extra_installs = ["sphinx-autobuild"] if args.serve else []
+    serve = args.builder == "html" and session.interactive
+    extra_installs = ["sphinx-autobuild"] if serve else []
     session.install(*BUILD_REQUIREMENTS, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]")
     session.chdir("docs")
@@ -106,7 +113,7 @@ def docs(session: nox.Session) -> None:
         *posargs,
     )
 
-    if args.serve:
+    if serve:
         session.run("sphinx-autobuild", *shared_args)
     else:
         session.run("sphinx-build", "--keep-going", *shared_args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ tnflow = [
     "networkx",
 ]
 test = ["pytest>=7.0"]
-coverage = ["mqt.ddsim[test]", "pytest-cov"]
+coverage = ["mqt.ddsim[test]", "pytest-cov>=4"]
 docs = [
     "mqt.ddsim[tnflow]",
     "furo>=2023.08.17",

--- a/test/python/constraints.txt
+++ b/test/python/constraints.txt
@@ -1,5 +1,0 @@
-scikit-build-core==0.8.1
-setuptools-scm==7.0.0
-pybind11==2.12.0
-pytest==7.0.0
-qiskit==1.0.0


### PR DESCRIPTION
## Description

This PR updates the CI configuration to use uv by Astral (the creators of ruff), which is an extremely fast Python package installer and resolver, written in Rust. It is sesigned as a drop-in replacement for common pip and pip-tools workflows.
See https://github.com/astral-sh/uv

Similar to ruff, it is extremely fast and in very active development. This should speed up any of the Python-based CI runs without much confirguration overhead.

This PR refactors the `minimums` check to make use of `uv`'s `--resolution=lowest-direct" feature. This allows us to completely get rid of the `constraints.txt` file. 
Furthermore, it makes use of the new versions of `mqt-core`'s reusable workflows.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
