### PR TITLE
⚡🔧 Faster cibuildwheel and better Windows wheel repair

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@dependabot/github_actions/github-actions-dfafb25d9f
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@dependabot/github_actions/github-actions-dfafb25d9f
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.1
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.2
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.2
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.2
     with:
       cmake-args: ""
       cmake-args-ubuntu: -G Ninja
@@ -31,19 +31,19 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.2
 
   python-tests:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.2
 
   code-ql:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.2
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.1
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.1
     with:
       cmake-args: ""
       cmake-args-ubuntu: -G Ninja
@@ -31,19 +31,19 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.1
 
   python-tests:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.1
 
   code-ql:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.1
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ skip = "*-musllinux_*"
 archs = "auto64"
 test-command = "python -c \"from mqt import ddsim\""
 test-skip = "cp38-macosx_arm64"
-build-frontend = "build"
+build-frontend = "build[uv]"
 
 [tool.cibuildwheel.linux]
 environment = { DEPLOY = "ON" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,6 @@ environment = { DEPLOY = "ON" }
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel"
-repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel}"
+before-build = "pip install delvewheel>=1.4.0"
+repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_ARGS = "-T ClangCL" }


### PR DESCRIPTION
## Description

This PR makes use of `cibuildwheel`'s latest addition of a `build[uv]` build frontend option that uses `uv` under the hood to speed up the build process.
Furthermore, it adjusts the Windows repair command to respect namespace packages.

Before: `11h 23m 43s`, After: `10h 59m 31s`

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
