### PR TITLE
🧱 include MQT Core via FetchContent instead of as a submodule

### DIFF
--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -14,9 +14,13 @@ on:
     paths:
       - .github/workflows/update-mqt-core.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.2
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.3
     with:
       update-to-head: ${{ github.event.inputs.update-to-head || false }}

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -1,0 +1,17 @@
+name: Update MQT Core
+on:
+  schedule:
+    # run once a month on the first day of the month at 00:00 UTC
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/update-mqt-core.yml
+
+jobs:
+  update-mqt-core:
+    name: ⬆️ Update MQT Core
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.1
+    with:
+      # Replace with a PAT if the created PRs should automatically trigger workflows.
+      token: ${{ github.token }}

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -12,6 +12,6 @@ jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.1
-    with:
+    secrets:
       # Replace with a PAT if the created PRs should automatically trigger workflows.
       token: ${{ github.token }}

--- a/.github/workflows/update-mqt-core.yml
+++ b/.github/workflows/update-mqt-core.yml
@@ -4,6 +4,12 @@ on:
     # run once a month on the first day of the month at 00:00 UTC
     - cron: "0 0 1 * *"
   workflow_dispatch:
+    inputs:
+      update-to-head:
+        description: "Update to the latest commit on the default branch"
+        type: boolean
+        required: false
+        default: false
   pull_request:
     paths:
       - .github/workflows/update-mqt-core.yml
@@ -11,7 +17,6 @@ on:
 jobs:
   update-mqt-core:
     name: ⬆️ Update MQT Core
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.1
-    secrets:
-      # Replace with a PAT if the created PRs should automatically trigger workflows.
-      token: ${{ github.token }}
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-mqt-core-update.yml@v1.1.2
+    with:
+      update-to-head: ${{ github.event.inputs.update-to-head || false }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "extern/mqt-core"]
-	path = extern/mqt-core
-	url = https://github.com/cda-tum/mqt-core.git
-    branch = main

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -19,20 +19,17 @@ if(BUILD_MQT_DDSIM_BINDINGS)
   find_package(pybind11 CONFIG REQUIRED)
 endif()
 
-set(FETCHCONTENT_SOURCE_DIR_MQT-CORE
-    ${PROJECT_SOURCE_DIR}/extern/mqt-core
-    CACHE
-      PATH
-      "Path to the source directory of the mqt-core library. This variable is used by FetchContent to download the library if it is not already available."
-)
-set(MQT_CORE_VERSION
-    2.2.2
+# cmake-format: off
+set(MQT_CORE_VERSION 2.5.1
     CACHE STRING "MQT Core version")
+set(MQT_CORE_REV "0e4ff9e0521886449027b252c65913e1afa863b0"
+    CACHE STRING "MQT Core identifier (tag, branch or commit hash)")
+# cmake-format: on
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
   FetchContent_Declare(
     mqt-core
     GIT_REPOSITORY https://github.com/cda-tum/mqt-core.git
-    GIT_TAG v${MQT_CORE_VERSION}
+    GIT_TAG ${MQT_CORE_REV}
     FIND_PACKAGE_ARGS ${MQT_CORE_VERSION})
   list(APPEND FETCH_PACKAGES mqt-core)
 else()
@@ -41,7 +38,7 @@ else()
     FetchContent_Declare(
       mqt-core
       GIT_REPOSITORY https://github.com/cda-tum/mqt-core.git
-      GIT_TAG v${MQT_CORE_VERSION})
+      GIT_TAG ${MQT_CORE_REV})
     list(APPEND FETCH_PACKAGES mqt-core)
   endif()
 endif()


### PR DESCRIPTION
## Description

https://github.com/cda-tum/mqt-core was included as a submodule so far. This PR removes this submodule and uses the existing fetch content commands to include this dependency.

Furthermore, it adds a dependabot-like update workflow for the FetchContent-managed mqt-core dependency.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
