### PR TITLE
⚡ only build bindings target for Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,10 @@ build-dir = "build/{wheel_tag}"
 # Explicitly set the package directory
 wheel.packages = ["src/mqt"]
 
+# Only build the Python bindings target
+cmake.targets = ["pyddsim"]
+
+# Only install the Python package component
 install.components = ["mqt-ddsim_Python"]
 
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"


### PR DESCRIPTION
## Description

This PR slighlty optimizes the build times for the Python package by only building the `pyddsim` bindings target. This avoid compiling targets that will never make it into the final wheel.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
