### PR TITLE
📦 add artifact attestation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,8 @@ jobs:
       url: https://pypi.org/p/mqt.ddsim
     permissions:
       id-token: write
+      attestations: write
+      contents: read
     needs: [python-packaging]
     steps:
       - uses: actions/download-artifact@v4
@@ -28,4 +30,8 @@ jobs:
           pattern: cibw-*
           path: dist
           merge-multiple: true
+      - name: Generate artifact attestation for sdist and wheel(s)
+        uses: actions/attest-build-provenance@v1.3.2
+        with:
+          subject-path: "dist/*"
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Description

This PR enables artifact attestations for the sdist and wheels produced via the continous deployment job.
This allows users to verify that the artifacts were built using our GitHub Action.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
