### PR TITLE
🐛 properly initialize `rootEdge`

### DIFF
--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -193,7 +193,7 @@ public:
 
   std::unique_ptr<dd::Package<Config>> dd =
       std::make_unique<dd::Package<Config>>();
-  dd::vEdge rootEdge{};
+  dd::vEdge rootEdge = dd::vEdge::one();
 
 protected:
   std::mt19937_64 mt;

--- a/test/test_circuit_sim.cpp
+++ b/test/test_circuit_sim.cpp
@@ -383,3 +383,10 @@ TEST(CircuitSimTest, QFTDynamicTest) {
   const auto result = circSim->simulate(1024U);
   EXPECT_GE(result.size(), 1);
 }
+
+TEST(CircuitSimTest, GetVectorBeforeSimulate) {
+  auto qc = std::make_unique<qc::QuantumComputation>(1);
+  const CircuitSimulator ddsim(std::move(qc));
+  const auto vec = ddsim.getVector();
+  EXPECT_EQ(vec[0], 1.);
+}


### PR DESCRIPTION
## Description

Fixes #404 

The `rootEdge` was not properly initialized, which led to `rootEdge.w.r == rootEdge.w.i == nullptr` and henceforth a nullptr dereference in the `RealNumber::val` method.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
