### PR TITLE
⬆️ require pybind11 >= 2.13.5

### DIFF
--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -16,7 +16,7 @@ if(BUILD_MQT_DDSIM_BINDINGS)
   endif()
 
   # add pybind11 library
-  find_package(pybind11 2.13 CONFIG REQUIRED)
+  find_package(pybind11 2.13.5 CONFIG REQUIRED)
 endif()
 
 # cmake-format: off

--- a/noxfile.py
+++ b/noxfile.py
@@ -28,7 +28,7 @@ PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 BUILD_REQUIREMENTS = [
     "scikit-build-core[pyproject]>=0.10.1",
     "setuptools_scm>=7",
-    "pybind11>=2.13",
+    "pybind11>=2.13.5",
     "wheel>=0.40",  # transitive dependency of pytest on Windows
 ]
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 # and get better caching performance. This only concerns dependencies that are
 # not available via wheels on PyPI (i.e., only as source distributions).
 BUILD_REQUIREMENTS = [
-    "scikit-build-core[pyproject]>=0.10.1",
+    "scikit-build-core>=0.10.1",
     "setuptools_scm>=7",
     "pybind11>=2.13.5",
     "wheel>=0.40",  # transitive dependency of pytest on Windows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["scikit-build-core>=0.10.1", "setuptools-scm>=7", "pybind11>=2.13"]
+requires = [
+  "scikit-build-core>=0.10.1",
+  "setuptools-scm>=7",
+  "pybind11>=2.13.5",
+]
 build-backend = "scikit_build_core.build"
 
 [project]


### PR DESCRIPTION
## Description

This small PR updates the requirement on pybind11 to `2.13.5` which contains a fix for some relative paths that could trip up compilers.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
