### PR TITLE
🔥 drop Python 3.8 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ if(BUILD_MQT_DDSIM_BINDINGS)
 
   # top-level call to find Python
   find_package(
-    Python 3.8 REQUIRED
+    Python 3.9 REQUIRED
     COMPONENTS Interpreter Development.Module
     OPTIONAL_COMPONENTS Development.SABIModule)
 endif()

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have any questions, feel free to contact us via [quantum.cda@xcit.tum.de]
 
 ## Getting Started
 
-DDSIM bundled with the provider and backends for Qiskit is available via [PyPI](https://pypi.org/project/mqt.ddsim/) for Linux, macOS, and Windows and supports Python 3.8 to 3.12.
+DDSIM bundled with the provider and backends for Qiskit is available via [PyPI](https://pypi.org/project/mqt.ddsim/) for Linux, macOS, and Windows and supports Python 3.9 to 3.13.
 
 ```console
 (venv) $ pip install mqt.ddsim

--- a/docs/source/Installation.rst
+++ b/docs/source/Installation.rst
@@ -34,9 +34,9 @@ In most practical cases (under 64-bit Linux, MacOS, and Windows), this requires 
         (venv) $ pip install --upgrade pip setuptools wheel
 
 .. warning::
-    Python 3.7 will reach end-of-life in June 2023 and MQT phases out support starting now.
-    We strongly recommend that users upgrade to a more recent version of Python to ensure compatibility and continue receiving updates and support.
-    Thank you for your understanding.
+     As of version 2.0.0, support for Python 3.8 has been officially dropped.
+     We strongly recommend that users upgrade to a more recent version of Python to ensure compatibility and continue receiving updates and support.
+     Thank you for your understanding.
 
 
 A Detailed Walk Through

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+PYTHON_ALL_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 # The following lists all the build requirements for building the package.
 # Note that this includes transitive build dependencies of package dependencies,
@@ -104,18 +104,17 @@ def docs(session: nox.Session) -> None:
     extra_installs = ["sphinx-autobuild"] if serve else []
     session.install(*BUILD_REQUIREMENTS, *extra_installs)
     session.install("--no-build-isolation", "-ve.[docs]", "--reinstall-package", "mqt.ddsim")
-    session.chdir("docs")
 
     if args.builder == "linkcheck":
-        session.run("sphinx-build", "-b", "linkcheck", "source", "_build/linkcheck", *posargs)
+        session.run("sphinx-build", "-b", "linkcheck", "docs", "docs/_build/linkcheck", *posargs)
         return
 
     shared_args = (
         "-n",  # nitpicky mode
         "-T",  # full tracebacks
         f"-b={args.builder}",
-        "source",
-        f"_build/{args.builder}",
+        "docs",
+        f"docs/_build/{args.builder}",
         *posargs,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -37,7 +36,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Development Status :: 5 - Production/Stable",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "qiskit[qasm3-import]>=1.0.0"
 ]
@@ -171,7 +170,7 @@ report.exclude_also = [
 [tool.mypy]
 files = ["src/mqt", "test/python"]
 mypy_path = ["$MYPY_CONFIG_FILE_DIR/src"]
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_configs = true
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
@@ -286,7 +285,7 @@ build = "cp3*"
 skip = "*-musllinux_*"
 archs = "auto64"
 test-command = "python -c \"from mqt import ddsim\""
-test-skip = ["cp38-macosx_arm64", "cp313*"] # skip testing on Python 3.13 until our dependencies are ready
+test-skip = ["cp313*"] # skip testing on Python 3.13 until our dependencies are ready
 build-frontend = "build[uv]"
 free-threaded-support = true
 manylinux-x86_64-image = "manylinux_2_28"

--- a/src/mqt/ddsim/provider.py
+++ b/src/mqt/ddsim/provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, List, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from qiskit.providers import BackendV2
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -70,7 +70,7 @@ class DDSIMProvider:
         backends = [
             backend_cls() for backend_name, backend_cls in self._BACKENDS if name is None or backend_name == name
         ]
-        return cast(List[BackendV2], filter_backends(backends, filters=filters, **kwargs))
+        return cast(list[BackendV2], filter_backends(backends, filters=filters, **kwargs))
 
     def __str__(self) -> str:
         """Return the provider name."""


### PR DESCRIPTION
## Description

Python 3.8 will reach end of live in October 2024.
Qiskit is already issuing deprecation warnings since a couple of releases when using it on Python 3.8.
This PR officially drops support for Python 3.8 in mqt-ddsim.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
