### PR TITLE
🚨 enable ruff's `D` code for docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,10 +246,10 @@ isort.required-imports = ["from __future__ import annotations"]
 "typing.Set".msg = "Use collections.abc.Set instead."
 
 [tool.ruff.lint.per-file-ignores]
-"test/python/**" = ["T20", "ANN", "D"]
+"test/python/**" = ["T20", "ANN", "D10"]
 "docs/**" = ["T20"]
 "noxfile.py" = ["T20", "TID251"]
-"*.pyi" = ["D"]  # pydocstyle
+"*.pyi" = ["D418", "PYI021"]  # pydocstyle
 "*.ipynb" = [
     "D",    # pydocstyle
     "E402", # Allow imports to appear anywhere in Jupyter notebooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,13 @@ ignore = [
 ]
 isort.required-imports = ["from __future__ import annotations"]
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.Callable".msg = "Use collections.abc.Callable instead."
+"typing.Iterator".msg = "Use collections.abc.Iterator instead."
+"typing.Mapping".msg = "Use collections.abc.Mapping instead."
+"typing.Sequence".msg = "Use collections.abc.Sequence instead."
+"typing.Set".msg = "Use collections.abc.Set instead."
+
 [tool.ruff.lint.per-file-ignores]
 "test/python/**" = ["T20", "ANN", "D"]
 "docs/**" = ["T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ extend-select = [
     "ASYNC",       # flake8-async
     "B",  "B904",  # flake8-bugbear
     "C4",          # flake8-comprehensions
-#    "D",           # pydocstyle
+    "D",           # pydocstyle
     "EM",          # flake8-errmsg
     "EXE",         # flake8-executable
     "FA",          # flake8-future-annotations

--- a/src/mqt/ddsim/__init__.py
+++ b/src/mqt/ddsim/__init__.py
@@ -1,3 +1,5 @@
+"""MQT DDSim Python Package."""
+
 from __future__ import annotations
 
 from ._version import version as __version__

--- a/src/mqt/ddsim/deterministicnoisesimulator.py
+++ b/src/mqt/ddsim/deterministicnoisesimulator.py
@@ -25,6 +25,12 @@ class DeterministicNoiseSimulatorBackend(QasmSimulatorBackend):
         name: str = "dd_simulator_density_matrix",
         description: str = "MQT DDSIM noise-aware density matrix simulator based on decision diagrams",
     ) -> None:
+        """Constructor for the DDSIM density matrix simulator backend.
+
+        Args:
+            name: The name of the backend.
+            description: The description of the backend.
+        """
         super().__init__(name=name, description=description)
 
     @classmethod

--- a/src/mqt/ddsim/header.py
+++ b/src/mqt/ddsim/header.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 @dataclass
 class DDSIMHeader(QobjExperimentHeader):  # type: ignore[misc]
+    """Qiskit experiment header for DDSIM backends."""
+
     name: str
     n_qubits: int
     memory_slots: int
@@ -23,6 +25,7 @@ class DDSIMHeader(QobjExperimentHeader):  # type: ignore[misc]
     qubit_labels: list[tuple[str, int]]
 
     def __init__(self, qc: QuantumCircuit) -> None:
+        """Initialize a new DDSIM experiment header."""
         # no call to super class constructor because this would trigger deprecation warnings
         self.name = qc.name
         self.n_qubits = qc.num_qubits

--- a/src/mqt/ddsim/hybridqasmsimulator.py
+++ b/src/mqt/ddsim/hybridqasmsimulator.py
@@ -38,6 +38,12 @@ class HybridQasmSimulatorBackend(QasmSimulatorBackend):
         name: str = "hybrid_qasm_simulator",
         description: str = "MQT DDSIM Hybrid Schrodinger-Feynman simulator",
     ) -> None:
+        """Constructor for the DDSIM Hybrid Schrodinger-Feynman simulator backend.
+
+        Args:
+            name: The name of the backend.
+            description: The description of the backend.
+        """
         super().__init__(name=name, description=description)
 
     @classmethod
@@ -52,6 +58,7 @@ class HybridQasmSimulatorBackend(QasmSimulatorBackend):
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._HSF_TARGET
 
     def _run_experiment(self, qc: QuantumCircuit, **options: Any) -> ExperimentResult:

--- a/src/mqt/ddsim/hybridstatevectorsimulator.py
+++ b/src/mqt/ddsim/hybridstatevectorsimulator.py
@@ -17,6 +17,7 @@ class HybridStatevectorSimulatorBackend(HybridQasmSimulatorBackend):
     )
 
     def __init__(self) -> None:
+        """Constructor for the DDSIM Hybrid Schrodinger-Feynman Statevector simulator backend."""
         super().__init__(
             name="hybrid_statevector_simulator",
             description="MQT DDSIM Hybrid Schrodinger-Feynman Statevector simulator",
@@ -24,4 +25,5 @@ class HybridStatevectorSimulatorBackend(HybridQasmSimulatorBackend):
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._HSF_SV_TARGET

--- a/src/mqt/ddsim/job.py
+++ b/src/mqt/ddsim/job.py
@@ -1,3 +1,5 @@
+"""Job module for DDSIM backend."""
+
 from __future__ import annotations
 
 import functools
@@ -17,8 +19,7 @@ if TYPE_CHECKING:
 
 
 def requires_submit(func: Callable[..., Any]) -> Callable[..., Any]:
-    """Decorator to ensure that a submit has been performed before
-    calling the method.
+    """Decorator to ensure that a submit has been performed before calling the method.
 
     Args:
         func (callable): test function to be decorated.
@@ -55,6 +56,16 @@ class DDSIMJob(JobV1):  # type: ignore[misc]
         parameter_values: Sequence[Parameters] | None,
         **args: dict[str, Any],
     ) -> None:
+        """Constructor.
+
+        Args:
+            backend: the backend instance used to run the job.
+            job_id: job ID.
+            fn: function to be run by the job.
+            experiments: circuits to be executed.
+            parameter_values: the parameters for each circuit.
+            args: additional arguments for the function
+        """
         super().__init__(backend, job_id)
         self._fn = fn
         self._experiments = experiments
@@ -83,15 +94,17 @@ class DDSIMJob(JobV1):  # type: ignore[misc]
     @requires_submit
     def result(self, timeout: float | None = None) -> Result:
         # pylint: disable=arguments-differ
-        """Get job result. The behavior is the same as the underlying
+        """Get job result.
+
+        The behavior is the same as the underlying
         concurrent Future objects,
         https://docs.python.org/3/library/concurrent.futures.html#future-objects.
 
         Args:
-            timeout (float): number of seconds to wait for results.
+            timeout: number of seconds to wait for results.
 
         Returns:
-            qiskit.Result: Result object
+            Result object
         Raises:
             concurrent.futures.TimeoutError: if timeout occurred.
             concurrent.futures.CancelledError: if job cancelled before completed.

--- a/src/mqt/ddsim/job.py
+++ b/src/mqt/ddsim/job.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import functools
 from concurrent import futures
-from typing import TYPE_CHECKING, Any, Callable, Mapping, Sequence, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from qiskit.providers import JobError, JobStatus, JobV1
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
     from qiskit import QuantumCircuit
     from qiskit.circuit import Parameter
     from qiskit.circuit.parameterexpression import ParameterValueType

--- a/src/mqt/ddsim/pathqasmsimulator.py
+++ b/src/mqt/ddsim/pathqasmsimulator.py
@@ -23,6 +23,14 @@ from .target import DDSIMTargetBuilder
 
 
 def read_tensor_network_file(filename: str) -> list[Tensor]:
+    """Read a tensor network from a file.
+
+    Args:
+        filename: The name of the file to read the tensor network from.
+
+    Returns:
+        The tensor network read from the file.
+    """
     import numpy as np
     import pandas as pd
     import quimb.tensor as qtn
@@ -41,6 +49,14 @@ def read_tensor_network_file(filename: str) -> list[Tensor]:
 
 
 def create_tensor_network(qc: QuantumCircuit) -> TensorNetwork:
+    """Create a tensor network from a quantum circuit.
+
+    Args:
+        qc: The quantum circuit to be simulated.
+
+    Returns:
+        The tensor network representing the quantum circuit.
+    """
     import quimb.tensor as qtn
     import sparse
 
@@ -87,6 +103,19 @@ def get_simulation_path(
     dump_path: bool = True,
     plot_ring: bool = False,
 ) -> list[tuple[int, int]]:
+    """Determine a simulation path via computing a contraction path using cotengra.
+
+    Args:
+        qc: The quantum circuit to be simulated.
+        max_time: The maximum time in seconds to spend on optimization.
+        max_repeats: The maximum number of repetitions for optimization.
+        parallel_runs: The number of parallel runs for optimization.
+        dump_path: Whether to dump the path to a file.
+        plot_ring: Whether to plot the contraction tree as a ring.
+
+    Returns:
+        The simulation path as a list of tuples.
+    """
     import cotengra as ctg
     from opt_einsum.paths import linear_to_ssa
 
@@ -134,6 +163,12 @@ class PathQasmSimulatorBackend(QasmSimulatorBackend):
         name: str = "path_sim_qasm_simulator",
         description: str = "MQT DDSIM Simulation Path Framework",
     ) -> None:
+        """Constructor for the DDSIM Simulation Path Framework QASM Simulator backend.
+
+        Args:
+            name: The name of the backend.
+            description: The description of the backend.
+        """
         super().__init__(name=name, description=description)
 
     @classmethod
@@ -156,6 +191,7 @@ class PathQasmSimulatorBackend(QasmSimulatorBackend):
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._PATH_TARGET
 
     def _run_experiment(self, qc: QuantumCircuit, **options: Any) -> ExperimentResult:

--- a/src/mqt/ddsim/pathstatevectorsimulator.py
+++ b/src/mqt/ddsim/pathstatevectorsimulator.py
@@ -17,6 +17,7 @@ class PathStatevectorSimulatorBackend(PathQasmSimulatorBackend):
     )
 
     def __init__(self) -> None:
+        """Constructor for the DDSIM Simulation Path Framework Statevector Simulator backend."""
         super().__init__(
             name="path_sim_statevector_simulator",
             description="MQT DDSIM Simulation Path Framework Statevector Simulator",
@@ -24,4 +25,5 @@ class PathStatevectorSimulatorBackend(PathQasmSimulatorBackend):
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._Path_SV_TARGET

--- a/src/mqt/ddsim/primitives/estimator.py
+++ b/src/mqt/ddsim/primitives/estimator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import accumulate
-from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit
@@ -15,6 +15,8 @@ from mqt.ddsim.pyddsim import CircuitSimulator
 from mqt.ddsim.qasmsimulator import QasmSimulatorBackend
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from qiskit.circuit import Parameter
     from qiskit.circuit.parameterexpression import ParameterValueType
 

--- a/src/mqt/ddsim/primitives/estimator.py
+++ b/src/mqt/ddsim/primitives/estimator.py
@@ -1,4 +1,4 @@
-"""Estimator implementation using DDSIM CircuitSimulator"""
+"""Estimator implementation using DDSIM CircuitSimulator."""
 
 from __future__ import annotations
 
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 class Estimator(QiskitEstimator):  # type: ignore[misc]
     """DDSIM implementation of qiskit's sampler.
+
     Code adapted from Qiskit's BackendEstimator class.
     """
 
@@ -31,7 +32,7 @@ class Estimator(QiskitEstimator):  # type: ignore[misc]
         options: dict[str, Any] | None = None,
         abelian_grouping: bool = False,
     ) -> None:
-        """Initialize a new Estimator instance
+        """Initialize a new Estimator instance.
 
         Args:
             options: Default options.
@@ -50,8 +51,7 @@ class Estimator(QiskitEstimator):  # type: ignore[misc]
     def preprocessed_circuits(
         self,
     ) -> tuple[list[QuantumCircuit], list[list[QuantumCircuit]]]:
-        """
-        Generate quantum circuits for states and observables produced by preprocessing.
+        """Generate quantum circuits for states and observables produced by preprocessing.
 
         Returns:
         Tuple: A tuple containing two entries:
@@ -62,8 +62,7 @@ class Estimator(QiskitEstimator):  # type: ignore[misc]
         return self._preprocessed_circuits
 
     def _preprocessing(self) -> tuple[list[QuantumCircuit], list[list[QuantumCircuit]]]:
-        """
-        Perform preprocessing for circuit arranging and packaging.
+        """Perform preprocessing for circuit arranging and packaging.
 
         Returns:
         Tuple:
@@ -116,8 +115,7 @@ class Estimator(QiskitEstimator):  # type: ignore[misc]
 
     @staticmethod
     def _observable_circuit(num_qubits: int, pauli: Pauli) -> tuple[QuantumCircuit, list[int]]:
-        """
-        Creates the quantum circuit representation of an observable given as a Pauli string.
+        """Creates the quantum circuit representation of an observable given as a Pauli string.
 
         Parameters:
             - num_qubits: Number of qubits of the observable.
@@ -197,8 +195,7 @@ class Estimator(QiskitEstimator):  # type: ignore[misc]
 
     @staticmethod
     def _postprocessing(result_list: list[float], accum: list[int], metadata: list[dict[str, Any]]) -> EstimatorResult:
-        """
-        Perform postprocessing for the evaluation of expectation values.
+        """Perform postprocessing for the evaluation of expectation values.
 
         Parameters:
         - result_list (list[float]): A list of measurement results.

--- a/src/mqt/ddsim/primitives/sampler.py
+++ b/src/mqt/ddsim/primitives/sampler.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from qiskit.primitives import SamplerResult
 from qiskit.primitives.sampler import Sampler as QiskitSampler
@@ -12,6 +12,8 @@ from qiskit.result import QuasiDistribution, Result
 from mqt.ddsim.qasmsimulator import QasmSimulatorBackend
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from qiskit.circuit import Parameter
     from qiskit.circuit.parameterexpression import ParameterValueType
 

--- a/src/mqt/ddsim/primitives/sampler.py
+++ b/src/mqt/ddsim/primitives/sampler.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class Sampler(QiskitSampler):  # type: ignore[misc]
+    """Sampler implementation using QasmSimulatorBackend."""
+
     _BACKEND = QasmSimulatorBackend()
 
     def __init__(
@@ -26,16 +28,16 @@ class Sampler(QiskitSampler):  # type: ignore[misc]
         *,
         options: dict[str, Any] | None = None,
     ) -> None:
-        """Initialize a new DDSIM Sampler
+        """Initialize a new DDSIM Sampler.
 
         Args:
             options: Default options.
         """
-
         super().__init__(options=options)
 
     @property
     def backend(self) -> QasmSimulatorBackend:
+        """The backend used by the sampler."""
         return self._BACKEND
 
     @property
@@ -49,7 +51,7 @@ class Sampler(QiskitSampler):  # type: ignore[misc]
         parameter_values: Sequence[Parameters],
         **run_options: Any,
     ) -> SamplerResult:
-        """Runs DDSIM backend
+        """Runs DDSIM backend.
 
         Args:
             circuits: List of circuit indices to simulate
@@ -59,14 +61,13 @@ class Sampler(QiskitSampler):  # type: ignore[misc]
         Returns:
             The result of the sampling process.
         """
-
         result = self.backend.run([self._circuits[i] for i in circuits], parameter_values, **run_options).result()
 
         return self._postprocessing(result, circuits)
 
     @staticmethod
     def _postprocessing(result: Result, circuits: Sequence[int]) -> SamplerResult:
-        """Converts counts into quasi-probability distributions
+        """Converts counts into quasi-probability distributions.
 
         Args:
             result: Result from DDSIM backend
@@ -75,7 +76,6 @@ class Sampler(QiskitSampler):  # type: ignore[misc]
         Returns:
             The result of the sampling process.
         """
-
         counts = result.get_counts()
         if not isinstance(counts, list):
             counts = [counts]

--- a/src/mqt/ddsim/provider.py
+++ b/src/mqt/ddsim/provider.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, cast
+from typing import TYPE_CHECKING, Any, List, cast
 
 from qiskit.providers import BackendV2
 from qiskit.providers.exceptions import QiskitBackendNotFoundError
@@ -17,6 +17,9 @@ from .qasmsimulator import QasmSimulatorBackend
 from .statevectorsimulator import StatevectorSimulatorBackend
 from .stochasticnoisesimulator import StochasticNoiseSimulatorBackend
 from .unitarysimulator import UnitarySimulatorBackend
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class DDSIMProvider:

--- a/src/mqt/ddsim/provider.py
+++ b/src/mqt/ddsim/provider.py
@@ -1,3 +1,5 @@
+"""Provider for DDSIM backends."""
+
 from __future__ import annotations
 
 from typing import Any, Callable, List, cast
@@ -18,6 +20,8 @@ from .unitarysimulator import UnitarySimulatorBackend
 
 
 class DDSIMProvider:
+    """Provider for DDSIM backends."""
+
     _BACKENDS = (
         ("qasm_simulator", QasmSimulatorBackend),
         ("statevector_simulator", StatevectorSimulatorBackend),
@@ -31,6 +35,12 @@ class DDSIMProvider:
     )
 
     def get_backend(self, name: str | None = None, **kwargs: Any) -> BackendV2:
+        """Return a backend matching the specified criteria.
+
+        Args:
+            name: Name of the backend.
+            kwargs: Additional filtering criteria.
+        """
         backends = self.backends(name, **kwargs)
         if len(backends) > 1:
             msg = "More than one backend matches the criteria"
@@ -47,10 +57,18 @@ class DDSIMProvider:
         filters: Callable[[list[BackendV2]], list[BackendV2]] | None = None,
         **kwargs: dict[str, Any],
     ) -> list[BackendV2]:
+        """Return a list of backends matching the specified criteria.
+
+        Args:
+            name: Name of the backend.
+            filters: Additional filtering criteria.
+            kwargs: Additional filtering criteria.
+        """
         backends = [
             backend_cls() for backend_name, backend_cls in self._BACKENDS if name is None or backend_name == name
         ]
         return cast(List[BackendV2], filter_backends(backends, filters=filters, **kwargs))
 
     def __str__(self) -> str:
+        """Return the provider name."""
         return "DDSIMProvider"

--- a/src/mqt/ddsim/qasmsimulator.py
+++ b/src/mqt/ddsim/qasmsimulator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from typing import TYPE_CHECKING, Any, Mapping, Sequence, Union, cast
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from qiskit import QuantumCircuit
 from qiskit.providers import BackendV2, Options
@@ -19,6 +19,8 @@ from .pyddsim import CircuitSimulator
 from .target import DDSIMTargetBuilder
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
     from qiskit.circuit import Parameter
     from qiskit.circuit.parameterexpression import ParameterValueType
 

--- a/src/mqt/ddsim/qasmsimulator.py
+++ b/src/mqt/ddsim/qasmsimulator.py
@@ -51,6 +51,7 @@ class QasmSimulatorBackend(BackendV2):  # type: ignore[misc]
         name: str = "qasm_simulator",
         description: str = "MQT DDSIM QASM Simulator",
     ) -> None:
+        """Constructor for the DDSIM QASM simulator backend."""
         super().__init__(name=name, description=description, backend_version=__version__)
         self._initialize_target()
 
@@ -68,10 +69,12 @@ class QasmSimulatorBackend(BackendV2):  # type: ignore[misc]
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._TARGET
 
     @property
     def max_circuits(self) -> int | None:
+        """Return the maximum number of circuits that can be run in a single job."""
         return None
 
     @staticmethod
@@ -79,6 +82,18 @@ class QasmSimulatorBackend(BackendV2):  # type: ignore[misc]
         quantum_circuits: Sequence[QuantumCircuit],
         parameter_values: Sequence[Parameters] | None,
     ) -> list[QuantumCircuit]:
+        """Assign parameter values to the circuits.
+
+        Args:
+            quantum_circuits: The quantum circuits to assign parameters to.
+            parameter_values: The parameter values to bind to the circuits.
+
+        Returns:
+            The bound circuits.
+
+        Raises:
+            ValueError: If the number of circuits does not match the number of provided parameter sets.
+        """
         if not any(qc.parameters for qc in quantum_circuits) and not parameter_values:
             return list(quantum_circuits)
 
@@ -106,6 +121,16 @@ class QasmSimulatorBackend(BackendV2):  # type: ignore[misc]
         parameter_values: Sequence[Parameters] | None = None,
         **options: Any,
     ) -> DDSIMJob:
+        """Run a quantum circuit or list of quantum circuits on the DDSIM backend.
+
+        Args:
+            quantum_circuits: The quantum circuit(s) to run.
+            parameter_values: The parameter values to bind to the circuits.
+            options: Additional run options.
+
+        Returns:
+            The DDSIM job
+        """
         if isinstance(quantum_circuits, QuantumCircuit):
             quantum_circuits = [quantum_circuits]
 

--- a/src/mqt/ddsim/statevectorsimulator.py
+++ b/src/mqt/ddsim/statevectorsimulator.py
@@ -17,8 +17,10 @@ class StatevectorSimulatorBackend(QasmSimulatorBackend):
     )
 
     def __init__(self) -> None:
+        """Constructor for the DDSIM Statevector simulator backend."""
         super().__init__(name="statevector_simulator", description="MQT DDSIM Statevector Simulator")
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._SV_TARGET

--- a/src/mqt/ddsim/stochasticnoisesimulator.py
+++ b/src/mqt/ddsim/stochasticnoisesimulator.py
@@ -25,6 +25,7 @@ class StochasticNoiseSimulatorBackend(QasmSimulatorBackend):
         name: str = "stochastic_dd_simulator",
         description: str = "MQT DDSIM noise-aware stochastic simulator based on decision diagrams",
     ) -> None:
+        """Constructor for the DDSIM stochastic simulator backend."""
         super().__init__(name=name, description=description)
 
     @classmethod

--- a/src/mqt/ddsim/target.py
+++ b/src/mqt/ddsim/target.py
@@ -13,13 +13,16 @@ if TYPE_CHECKING:
 
 
 class DDSIMTargetBuilder:
+    """Class for building DDSIM targets."""
+
     @classmethod
     def add_0q_gates(cls, target: Target) -> None:
-        with contextlib.suppress(AttributeError):
-            target.add_instruction(qcl.GlobalPhaseGate(Parameter("phase")))
+        """Add 0-qubit gates to the target."""
+        target.add_instruction(qcl.GlobalPhaseGate(Parameter("phase")))
 
     @classmethod
     def add_1q_clifford_gates(cls, target: Target) -> None:
+        """Add 1-qubit Clifford gates to the target."""
         target.add_instruction(qcl.IGate())
         target.add_instruction(qcl.XGate())
         target.add_instruction(qcl.YGate())
@@ -32,6 +35,7 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_1q_gates(cls, target: Target) -> None:
+        """Add 1-qubit gates to the target."""
         cls.add_1q_clifford_gates(target)
 
         theta = Parameter("theta")
@@ -50,12 +54,14 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_2q_controlled_clifford_gates(cls, target: Target) -> None:
+        """Add 2-qubit controlled Clifford gates to the target."""
         target.add_instruction(qcl.CXGate())
         target.add_instruction(qcl.CYGate())
         target.add_instruction(qcl.CZGate())
 
     @classmethod
     def add_2q_controlled_gates(cls, target: Target) -> None:
+        """Add 2-qubit controlled gates to the target."""
         cls.add_2q_controlled_clifford_gates(target)
 
         theta = Parameter("theta")
@@ -76,6 +82,7 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_2q_non_controlled_clifford_gates(cls, target: Target) -> None:
+        """Add 2-qubit non-controlled Clifford gates to the target."""
         target.add_instruction(qcl.SwapGate())
         target.add_instruction(qcl.iSwapGate())
         target.add_instruction(qcl.DCXGate())
@@ -83,6 +90,7 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_2q_non_controlled_gates(cls, target: Target) -> None:
+        """Add 2-qubit non-controlled gates to the target."""
         cls.add_2q_non_controlled_clifford_gates(target)
 
         beta = Parameter("beta")
@@ -97,11 +105,13 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_2q_gates(cls, target: Target) -> None:
+        """Add 2-qubit gates to the target."""
         cls.add_2q_controlled_gates(target)
         cls.add_2q_non_controlled_gates(target)
 
     @classmethod
     def add_3q_gates(cls, target: Target) -> None:
+        """Add 3-qubit gates to the target."""
         target.add_instruction(qcl.CCXGate())
         target.add_instruction(qcl.CSwapGate())
         with contextlib.suppress(AttributeError):
@@ -109,6 +119,7 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_multi_qubit_gates(cls, target: Target) -> None:
+        """Add multi-qubit gates to the target."""
         target.add_instruction(qcl.MCXGate, name="mcx")
         target.add_instruction(qcl.MCXGrayCode, name="mcx_gray")
         target.add_instruction(qcl.MCXRecursive, name="mcx_recursive")
@@ -118,17 +129,21 @@ class DDSIMTargetBuilder:
 
     @classmethod
     def add_measure(cls, target: Target) -> None:
+        """Add a measure instruction to the target."""
         target.add_instruction(qcl.Measure())
 
     @classmethod
     def add_reset(cls, target: Target) -> None:
+        """Add a reset instruction to the target."""
         target.add_instruction(qcl.Reset())
 
     @classmethod
     def add_non_unitary_operations(cls, target: Target) -> None:
+        """Add non-unitary operations to the target."""
         cls.add_measure(target)
         cls.add_reset(target)
 
     @classmethod
     def add_barrier(cls, target: Target) -> None:
+        """Add a barrier instruction to the target."""
         target.add_instruction(qcl.Barrier, name="barrier")

--- a/src/mqt/ddsim/unitarysimulator.py
+++ b/src/mqt/ddsim/unitarysimulator.py
@@ -39,6 +39,7 @@ class UnitarySimulatorBackend(QasmSimulatorBackend):
         DDSIMTargetBuilder.add_barrier(target)
 
     def __init__(self) -> None:
+        """Constructor for the DDSIM unitary simulator backend."""
         super().__init__(name="unitary_simulator", description="MQT DDSIM Unitary Simulator")
 
     @classmethod
@@ -47,6 +48,7 @@ class UnitarySimulatorBackend(QasmSimulatorBackend):
 
     @property
     def target(self) -> Target:
+        """Return the target of the backend."""
         return self._US_TARGET
 
     @classmethod

--- a/src/mqt/ddsim/unitarysimulator.py
+++ b/src/mqt/ddsim/unitarysimulator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Any, Sequence
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import numpy.typing as npt
@@ -18,6 +18,8 @@ from .qasmsimulator import QasmSimulatorBackend
 from .target import DDSIMTargetBuilder
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from qiskit import QuantumCircuit
 
 

--- a/test/python/primitives/test_estimator.py
+++ b/test/python/primitives/test_estimator.py
@@ -68,7 +68,7 @@ def test_estimator_run_single_circuit__observable_no_params(
     observables: list[SparsePauliOp],
     estimator: Estimator,
 ) -> None:
-    """test for estimator with a single circuit/observable and no parameters"""
+    """Test for estimator with a single circuit/observable and no parameters."""
     circuit = circuits[0].assign_parameters([0, 1, 1, 2, 3, 5])
     observable = observables[0]
 
@@ -86,7 +86,7 @@ def test_estimator_run_single_circuit__observable_no_params(
 
 
 def test_run_with_operator(circuits: list[QuantumCircuit], estimator: Estimator) -> None:
-    """test for run with Operator as an observable"""
+    """Test for run with Operator as an observable."""
     circuit = circuits[0].assign_parameters([0, 1, 1, 2, 3, 5])
     matrix = SparsePauliOp.from_operator(
         Operator([
@@ -107,7 +107,7 @@ def test_estimator_run_single_circuit__observable_with_params(
     observables: list[SparsePauliOp],
     estimator: Estimator,
 ) -> None:
-    """test for estimator with a single circuit/observable and parameters"""
+    """Test for estimator with a single circuit/observable and parameters."""
     circuit = circuits[0]
     observable = observables[0]
 
@@ -129,7 +129,7 @@ def test_estimator_run_multiple_circuits_observables_no_params(
     observables: list[SparsePauliOp],
     estimator: Estimator,
 ) -> None:
-    """test for estimator with multiple circuits/observables and no parameters"""
+    """Test for estimator with multiple circuits/observables and no parameters."""
     qc_x, qc_y, qc_z = circuits[2]
     pauli_x, pauli_y, pauli_z = observables[2]
 
@@ -144,7 +144,7 @@ def test_estimator_run_multiple_circuits_observables_with_params(
     observables: list[SparsePauliOp],
     estimator: Estimator,
 ) -> None:
-    """test for estimator with multiple circuits/observables with parameters"""
+    """Test for estimator with multiple circuits/observables with parameters."""
     psi1, psi2 = circuits[1]
     hamiltonian_1, hamiltonian_2, hamiltonian_3 = observables[1]
     theta_1, theta_2, theta_3 = (
@@ -168,7 +168,7 @@ def test_estimator_sequenctial_run(
     observables: list[SparsePauliOp],
     estimator: Estimator,
 ) -> None:
-    """test for estimator's sequenctial run"""
+    """Test for estimator's sequenctial run."""
     psi1, psi2 = circuits[1]
     hamiltonian_1, hamiltonian_2, hamiltonian_3 = observables[1]
     theta_1, theta_2, theta_3 = (

--- a/test/python/primitives/test_sampler.py
+++ b/test/python/primitives/test_sampler.py
@@ -27,7 +27,6 @@ def shots() -> int:
 @pytest.fixture
 def circuits() -> list[QuantumCircuit]:
     """The circuit lists fixture for the tests in this file."""
-
     bell_1 = QuantumCircuit(2)
     bell_1.h(0)
     bell_1.cx(0, 1)
@@ -69,7 +68,7 @@ def compare_probs(
 
 
 def test_sampler_run_single_circuit(circuits: list[QuantumCircuit], sampler: Sampler, shots: int) -> None:
-    """Test Sampler.run() with single circuits"""
+    """Test Sampler.run() with single circuits."""
     bell = circuits[0]
     target = {0: 0.5, 1: 0, 2: 0, 3: 0.5}
     target_binary = {"00": 0.5, "11": 0.5, "01": 0, "10": 0}
@@ -120,6 +119,7 @@ def test_sampler_run_with_parameterized_circuits(circuits: list[QuantumCircuit],
 
 def test_sequential_run(circuits: list[QuantumCircuit], sampler: Sampler, shots: int) -> None:
     """Sampler stores the information about the circuits in an instance attribute.
+
     If the same instance is used multiple times, the attribute still keeps the information about the circuits involved in previous runs.
     This test ensures that if a circuit is analyzed in different runs, the information about this circuit is not saved twice.
     """


### PR DESCRIPTION
## Description

This PR (finally) enables ruff's `D` code for `pydocstyle` lint rules.
Consequently, it fixes all the resulting warnings.
Additionally, it adds rules for favoring `collections.abc` over `typing` where appropriate.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
