### PR TITLE
🛂 explicitly set workflow permissions to enable runs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.4
+    # Explicitly set permissions so that the workflows also work from forks.
+    permissions:
+      contents: read # Required for the `actions/checkout` action
+      id-token: write # Required for the `codecov/codecov-action` action
     with:
       cmake-args: ""
       cmake-args-ubuntu: -G Ninja
@@ -38,6 +42,10 @@ jobs:
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
     uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.4
+    # Explicitly set permissions so that the workflows also work from forks.
+    permissions:
+      contents: read # Required for the `actions/checkout` action
+      id-token: write # Required for the `codecov/codecov-action` action
 
   code-ql:
     name: 📝 CodeQL


### PR DESCRIPTION
## Description

This PR explicitly sets the permissions for the reusable workflows that need OIDC token permissions.
This should allow the workflows to properly work on PRs from forks.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
